### PR TITLE
Add sr-latin keymap

### DIFF
--- a/data/keymaps/i386/qwertz/sr-latin.map
+++ b/data/keymaps/i386/qwertz/sr-latin.map
@@ -1,0 +1,1 @@
+data/keymaps/i386/qwertz/slovene.map


### PR DESCRIPTION
When using localectl to set X11 keyboard to serbian latin, it suggests that console keymap should be changed to sr-latin. Since serbian latin is exactly the same as slovene keymap, we can just make link i386/qwertz/slovene.map -> i386/qwertz/sr-latin.map.