### PR TITLE
Add neo.map

### DIFF
--- a/data/keymaps/i386/neo/neo.map
+++ b/data/keymaps/i386/neo/neo.map
@@ -1,0 +1,981 @@
+#==========================================================================
+# README
+#==========================================================================
+# Neo2 Console Keymap
+#
+# Notes:
+# • Not using KP_-keysyms on fourth level as NumLock is not controllable
+#   (i.e. can't be forced to on whenever the keymap is loaded).
+#   On console there is little need for KP_-keysyms.
+# • Mod4-Lock is not implemented (technical difficulties, not enough levels)
+# • Dead keys only when there exists a corresponding dead keysym on console
+#   (i.e circumflex, gravis, cedille, trema, akut and tilde) otherwise the
+#   undead character is produced.
+# • Using default compose as for now. Maximum number allowed compose
+#   sequences seems to be 256, not enough for the standard Neo2 sequences.
+# • Wrong Caps_Lock behaviour with ssharp (not returning to lower case when
+#   using Caps_Lock and Shift)
+#   See: https://bugzilla.kernel.org/show_bug.cgi?id=7063
+
+#==========================================================================
+# Prelude
+#==========================================================================
+
+#keymaps 0-3,16-19,32-35,64-67,80-83,96-99
+keymaps 0-127
+compose as usual
+strings as usual
+
+#==========================================================================
+# Default Keys (usually not needed)
+#==========================================================================
+
+                keycode   1 = Escape
+            alt keycode   1 = Meta_Escape
+     shiftl alt keycode   1 = Meta_Escape
+     shiftr alt keycode   1 = Meta_Escape
+
+                keycode  14 = Delete
+            alt keycode  14 = Meta_Delete
+     shiftl alt keycode  14 = Meta_Delete
+     shiftr alt keycode  14 = Meta_Delete
+
+                keycode  15 = Tab
+         shiftl keycode  15 = Meta_Tab
+         shiftr keycode  15 = Meta_Tab
+            alt keycode  15 = Meta_Tab
+
+                keycode  28 = Return
+            alt keycode  28 = Meta_Control_m
+
+                keycode  29 = Control
+                keycode  97 = Control
+
+                keycode  56 = Alt
+
+#==========================================================================
+# linux-keys-bare, Control Keys
+#==========================================================================
+
+                keycode  59 = F1
+            alt keycode  59 = Console_1
+    control alt keycode  59 = Console_1
+         shiftl keycode  59 = F13
+         shiftr keycode  59 = F13
+                keycode  60 = F2
+            alt keycode  60 = Console_2
+    control alt keycode  60 = Console_2
+         shiftl keycode  60 = F14
+         shiftr keycode  60 = F14
+                keycode  61 = F3
+            alt keycode  61 = Console_3
+    control alt keycode  61 = Console_3
+         shiftl keycode  61 = F15
+         shiftr keycode  61 = F15
+                keycode  62 = F4
+            alt keycode  62 = Console_4
+    control alt keycode  62 = Console_4
+         shiftl keycode  62 = F16
+         shiftr keycode  62 = F16
+
+                keycode  63 = F5
+            alt keycode  63 = Console_5
+    control alt keycode  63 = Console_5
+         shiftl keycode  63 = F17
+         shiftr keycode  63 = F17
+                keycode  64 = F6
+            alt keycode  64 = Console_6
+    control alt keycode  64 = Console_6
+         shiftl keycode  64 = F18
+         shiftr keycode  64 = F18
+                keycode  65 = F7
+            alt keycode  65 = Console_7
+    control alt keycode  65 = Console_7
+         shiftl keycode  65 = F19
+         shiftr keycode  65 = F19
+                keycode  66 = F8
+            alt keycode  66 = Console_8
+    control alt keycode  66 = Console_8
+         shiftl keycode  66 = F20
+         shiftr keycode  66 = F20
+
+                keycode  67 = F9
+            alt keycode  67 = Console_9
+    control alt keycode  67 = Console_9
+         shiftl keycode  67 = F21
+         shiftr keycode  67 = F21
+                keycode  68 = F10
+            alt keycode  68 = Console_10
+    control alt keycode  68 = Console_10
+         shiftl keycode  68 = F22
+         shiftr keycode  68 = F22
+                keycode  87 = F11
+            alt keycode  87 = Console_11
+    control alt keycode  87 = Console_11
+         shiftl keycode  87 = F23
+         shiftr keycode  87 = F23
+                keycode  88 = F12
+            alt keycode  88 = Console_12
+    control alt keycode  88 = Console_12
+         shiftl keycode  88 = F24
+         shiftr keycode  88 = F24
+
+                keycode 103 = Up
+            alt keycode 103 = KeyboardSignal
+                keycode 105 = Left
+            alt keycode 105 = Decr_Console
+                keycode 106 = Right
+            alt keycode 106 = Incr_Console
+                keycode 108 = Down
+
+                keycode 110 = Insert
+                keycode 111 = Remove
+    control alt keycode 111 = Boot
+                keycode 102 = Home
+                keycode 107 = End
+                keycode 104 = PageUp
+         shiftl keycode 104 = Scroll_Backward
+         shiftr keycode 104 = Scroll_Backward
+                keycode 109 = PageDown
+         shiftl keycode 109 = Scroll_Forward
+         shiftr keycode 109 = Scroll_Forward
+
+                keycode  99 = Compose
+            alt keycode  99 = Control_backslash
+        control keycode  99 = Control_backslash
+          plain keycode  70 = Scroll_Lock
+         shiftl keycode  70 = Show_Memory
+         shiftr keycode  70 = Show_Memory
+        control keycode  70 = Show_State
+            alt keycode  70 = Show_Registers
+                keycode 119 = Pause
+
+## Alternatively:
+#
+#include "linux-keys-bare"
+#
+#         shiftl keycode  59 = F13
+#         shiftr keycode  59 = F13
+#         shiftl keycode  60 = F14
+#         shiftr keycode  60 = F14
+#         shiftl keycode  61 = F15
+#         shiftr keycode  61 = F15
+#         shiftl keycode  62 = F16
+#         shiftr keycode  62 = F16
+#
+#         shiftl keycode  63 = F17
+#         shiftr keycode  63 = F17
+#         shiftl keycode  64 = F18
+#         shiftr keycode  64 = F18
+#         shiftl keycode  65 = F19
+#         shiftr keycode  65 = F19
+#         shiftl keycode  66 = F20
+#         shiftr keycode  66 = F20
+#
+#         shiftl keycode  67 = F21
+#         shiftr keycode  67 = F21
+#         shiftl keycode  68 = F22
+#         shiftr keycode  68 = F22
+#         shiftl keycode  87 = F23
+#         shiftr keycode  87 = F23
+#         shiftl keycode  88 = F24
+#         shiftr keycode  88 = F24
+#
+#         shiftl keycode 104 = Scroll_Backward
+#         shiftr keycode 104 = Scroll_Backward
+#
+#         shiftl keycode 109 = Scroll_Forward
+#         shiftr keycode 109 = Scroll_Forward
+#
+#         shiftl keycode  70 = Show_Memory
+#         shiftr keycode  70 = Show_Memory
+
+#==========================================================================
+# Modifier
+#==========================================================================
+
+                keycode  42 = ShiftL
+        shiftr  keycode  42 = Caps_Lock
+                keycode  54 = ShiftR
+        shiftl  keycode  54 = Caps_Lock
+
+                keycode  58 = AltGr            # Mod3 Left
+                keycode  43 = AltGr            # Mod3 Right
+
+                keycode  86 = CtrlL            # Mod4 Left
+                keycode 100 = CtrlL            # Mod4 Right
+
+#==========================================================================
+# Compose
+#==========================================================================
+
+# TODO: add most important compose definitions
+
+        altgr   keycode  15 = Compose          # Mod3 + Tab: Compose
+
+#==========================================================================
+# Character keys
+#==========================================================================
+
+                keycode   2 = one              # 1 [U+0031] DIGIT ONE
+        shiftl  keycode   2 = degree           # ° [U+00B0] DEGREE SIGN
+        shiftr  keycode   2 = degree           # ° [U+00B0] DEGREE SIGN
+        altgr   keycode   2 = onesuperior      # ¹ [U+00B9] SUPERSCRIPT ONE
+        ctrll   keycode   2 = ordfeminine      # ª [U+00AA] FEMININE ORDINAL INDICATOR
+shiftl  ctrll   keycode   2 = ordfeminine      # ª [U+00AA] FEMININE ORDINAL INDICATOR
+shiftr  ctrll   keycode   2 = ordfeminine      # ª [U+00AA] FEMININE ORDINAL INDICATOR
+shiftl  altgr   keycode   2 = U+2081           # ₁ [U+2081] SUBSCRIPT ONE
+shiftr  altgr   keycode   2 = U+2081           # ₁ [U+2081] SUBSCRIPT ONE
+ctrll   altgr   keycode   2 = notsign          # ¬ [U+00AC] NOT SIGN
+
+                keycode   3 = two              # 2 [U+0032] DIGIT TWO
+        shiftl  keycode   3 = section          # § [U+00A7] SECTION SIGN
+        shiftr  keycode   3 = section          # § [U+00A7] SECTION SIGN
+        altgr   keycode   3 = twosuperior      # ² [U+00B2] SUPERSCRIPT TWO
+        ctrll   keycode   3 = masculine        # º [U+00BA] MASCULINE ORDINAL INDICATOR
+shiftl  ctrll   keycode   3 = masculine        # º [U+00BA] MASCULINE ORDINAL INDICATOR
+shiftr  ctrll   keycode   3 = masculine        # º [U+00BA] MASCULINE ORDINAL INDICATOR
+shiftl  altgr   keycode   3 = U+2082           # ₂ [U+2082] SUBSCRIPT TWO
+shiftr  altgr   keycode   3 = U+2082           # ₂ [U+2082] SUBSCRIPT TWO
+ctrll   altgr   keycode   3 = U+2228           # ∨ [U+2228] LOGICAL OR
+
+                keycode   4 = three            # 3 [U+0033] DIGIT THREE
+        shiftl  keycode   4 = U+2113           # ℓ [U+2113] SCRIPT SMALL L
+        shiftr  keycode   4 = U+2113           # ℓ [U+2113] SCRIPT SMALL L
+        altgr   keycode   4 = threesuperior    # ³ [U+00B3] SUPERSCRIPT THREE
+        ctrll   keycode   4 = U+2116           # № [U+2116] NUMERO SIGN
+shiftl  ctrll   keycode   4 = U+2116           # № [U+2116] NUMERO SIGN
+shiftr  ctrll   keycode   4 = U+2116           # № [U+2116] NUMERO SIGN
+shiftl  altgr   keycode   4 = U+2083           # ₃ [U+2083] SUBSCRIPT THREE
+shiftr  altgr   keycode   4 = U+2083           # ₃ [U+2083] SUBSCRIPT THREE
+ctrll   altgr   keycode   4 = U+2227           # ∧ [U+2227] LOGICAL AND
+
+                keycode   5 = four             # 4 [U+0034] DIGIT FOUR
+        shiftl  keycode   5 = guillemotright   # » [U+00BB] RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+        shiftr  keycode   5 = guillemotright   # » [U+00BB] RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+        altgr   keycode   5 = U+203a           # › [U+203A] SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+        ctrll   keycode   5 = VoidSymbol       #
+shiftl  ctrll   keycode   5 = VoidSymbol       #
+shiftr  ctrll   keycode   5 = VoidSymbol       #
+shiftl  altgr   keycode   5 = U+2640           # ♀ [U+2640] FEMALE SIGN
+shiftr  altgr   keycode   5 = U+2640           # ♀ [U+2640] FEMALE SIGN
+ctrll   altgr   keycode   5 = U+22a5           # ⊥ [U+22A5] UP TACK
+
+                keycode   6 = five             # 5 [U+0035] DIGIT FIVE
+        shiftl  keycode   6 = guillemotleft    # « [U+00AB] LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+        shiftr  keycode   6 = guillemotleft    # « [U+00AB] LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+        altgr   keycode   6 = U+2039           # ‹ [U+2039] SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+        ctrll   keycode   6 = periodcentered   # · [U+00B7] MIDDLE DOT
+shiftl  ctrll   keycode   6 = periodcentered   # · [U+00B7] MIDDLE DOT
+shiftr  ctrll   keycode   6 = periodcentered   # · [U+00B7] MIDDLE DOT
+shiftl  altgr   keycode   6 = U+2642           # ♂ [U+2642] MALE SIGN
+shiftr  altgr   keycode   6 = U+2642           # ♂ [U+2642] MALE SIGN
+ctrll   altgr   keycode   6 = U+2221           # ∡ [U+2221] MEASURED ANGLE
+
+                keycode   7 = six              # 6 [U+0036] DIGIT SIX
+        shiftl  keycode   7 = dollar           # $ [U+0024] DOLLAR SIGN
+        shiftr  keycode   7 = dollar           # $ [U+0024] DOLLAR SIGN
+        altgr   keycode   7 = cent             # ¢ [U+00A2] CENT SIGN
+        ctrll   keycode   7 = sterling         # £ [U+00A3] POUND SIGN
+shiftl  ctrll   keycode   7 = sterling         # £ [U+00A3] POUND SIGN
+shiftr  ctrll   keycode   7 = sterling         # £ [U+00A3] POUND SIGN
+shiftl  altgr   keycode   7 = U+26a5           # ⚥ [U+26A5] MALE AND FEMALE SIGN
+shiftr  altgr   keycode   7 = U+26a5           # ⚥ [U+26A5] MALE AND FEMALE SIGN
+ctrll   altgr   keycode   7 = U+2225           # ∥ [U+2225] PARALLEL TO
+
+                keycode   8 = seven            # 7 [U+0037] DIGIT SEVEN
+        shiftl  keycode   8 = U+20ac           # € [U+20AC] EURO SIGN
+        shiftr  keycode   8 = U+20ac           # € [U+20AC] EURO SIGN
+        altgr   keycode   8 = yen              # ¥ [U+00A5] YEN SIGN
+        ctrll   keycode   8 = currency         # ¤ [U+00A4] CURRENCY SIGN
+shiftl  ctrll   keycode   8 = currency         # ¤ [U+00A4] CURRENCY SIGN
+shiftr  ctrll   keycode   8 = currency         # ¤ [U+00A4] CURRENCY SIGN
+shiftl  altgr   keycode   8 = U+03f0           # ϰ [U+03F0] GREEK KAPPA SYMBOL
+shiftr  altgr   keycode   8 = U+03f0           # ϰ [U+03F0] GREEK KAPPA SYMBOL
+ctrll   altgr   keycode   8 = U+2192           # → [U+2192] RIGHTWARDS ARROW
+
+                keycode   9 = eight            # 8 [U+0038] DIGIT EIGHT
+        shiftl  keycode   9 = U+201e           # „ [U+201E] DOUBLE LOW-9 QUOTATION MARK
+        shiftr  keycode   9 = U+201e           # „ [U+201E] DOUBLE LOW-9 QUOTATION MARK
+        altgr   keycode   9 = U+201a           # ‚ [U+201A] SINGLE LOW-9 QUOTATION MARK
+        ctrll   keycode   9 = U+21e5           # ⇥ [U+21E5] RIGHTWARDS ARROW TO BAR
+shiftl  ctrll   keycode   9 = U+21e5           # ⇥ [U+21E5] RIGHTWARDS ARROW TO BAR
+shiftr  ctrll   keycode   9 = U+21e5           # ⇥ [U+21E5] RIGHTWARDS ARROW TO BAR
+shiftl  altgr   keycode   9 = U+27e8           # ⟨ [U+27E8] MATHEMATICAL LEFT ANGLE BRACKET
+shiftr  altgr   keycode   9 = U+27e8           # ⟨ [U+27E8] MATHEMATICAL LEFT ANGLE BRACKET
+ctrll   altgr   keycode   9 = U+221e           # ∞ [U+221E] INFINITY
+
+                keycode  10 = nine             # 9 [U+0039] DIGIT NINE
+        shiftl  keycode  10 = U+201c           # “ [U+201C] LEFT DOUBLE QUOTATION MARK
+        shiftr  keycode  10 = U+201c           # “ [U+201C] LEFT DOUBLE QUOTATION MARK
+        altgr   keycode  10 = U+2018           # ‘ [U+2018] LEFT SINGLE QUOTATION MARK
+        ctrll   keycode  10 = slash            # / [U+002F] SOLIDUS
+shiftl  ctrll   keycode  10 = slash            # / [U+002F] SOLIDUS
+shiftr  ctrll   keycode  10 = slash            # / [U+002F] SOLIDUS
+shiftl  altgr   keycode  10 = U+27e9           # ⟩ [U+27E9] MATHEMATICAL RIGHT ANGLE BRACKET
+shiftr  altgr   keycode  10 = U+27e9           # ⟩ [U+27E9] MATHEMATICAL RIGHT ANGLE BRACKET
+ctrll   altgr   keycode  10 = U+221d           # ∝ [U+221D] PROPORTIONAL TO
+
+                keycode  11 = zero             # 0 [U+0030] DIGIT ZERO
+        shiftl  keycode  11 = U+201d           # ” [U+201D] RIGHT DOUBLE QUOTATION MARK
+        shiftr  keycode  11 = U+201d           # ” [U+201D] RIGHT DOUBLE QUOTATION MARK
+        altgr   keycode  11 = U+2019           # ’ [U+2019] RIGHT SINGLE QUOTATION MARK
+        ctrll   keycode  11 = asterisk         # * [U+002A] ASTERISK
+shiftl  ctrll   keycode  11 = asterisk         # * [U+002A] ASTERISK
+shiftr  ctrll   keycode  11 = asterisk         # * [U+002A] ASTERISK
+shiftl  altgr   keycode  11 = U+2080           # ₀ [U+2080] SUBSCRIPT ZERO
+shiftr  altgr   keycode  11 = U+2080           # ₀ [U+2080] SUBSCRIPT ZERO
+ctrll   altgr   keycode  11 = U+2205           # ∅ [U+2205] EMPTY SET
+
+                keycode  12 = minus            # - [U+002D] HYPHEN-MINUS
+        shiftl  keycode  12 = U+2014           # — [U+2014] EM DASH
+        shiftr  keycode  12 = U+2014           # — [U+2014] EM DASH
+        altgr   keycode  12 = VoidSymbol       #
+        ctrll   keycode  12 = minus            # - [U+002D] HYPHEN-MINUS
+shiftl  ctrll   keycode  12 = minus            # - [U+002D] HYPHEN-MINUS
+shiftr  ctrll   keycode  12 = minus            # - [U+002D] HYPHEN-MINUS
+shiftl  altgr   keycode  12 = U+2011           # ‑ [U+2011] NON-BREAKING HYPHEN
+shiftr  altgr   keycode  12 = U+2011           # ‑ [U+2011] NON-BREAKING HYPHEN
+ctrll   altgr   keycode  12 = U+254c           # ╌ [U+254C] BOX DRAWINGS LIGHT DOUBLE DASH HORIZONTAL
+
+                keycode  16 = x                # x [U+0078] LATIN SMALL LETTER X
+shift   shiftl  keycode  16 = x                # x [U+0078] LATIN SMALL LETTER X
+shift   shiftr  keycode  16 = x                # x [U+0078] LATIN SMALL LETTER X
+        shiftl  keycode  16 = +X               # X [U+0058] LATIN CAPITAL LETTER X
+        shiftr  keycode  16 = +X               # X [U+0058] LATIN CAPITAL LETTER X
+        altgr   keycode  16 = U+2026           # … [U+2026] HORIZONTAL ELLIPSIS
+        ctrll   keycode  16 = Prior            #
+shiftl  ctrll   keycode  16 = Prior            #
+shiftr  ctrll   keycode  16 = Prior            #
+shiftl  altgr   keycode  16 = U+03be           # ξ [U+03BE] GREEK SMALL LETTER XI
+shiftr  altgr   keycode  16 = U+03be           # ξ [U+03BE] GREEK SMALL LETTER XI
+ctrll   altgr   keycode  16 = U+039e           # Ξ [U+039E] GREEK CAPITAL LETTER XI
+
+                keycode  17 = v                # v [U+0076] LATIN SMALL LETTER V
+shift   shiftl  keycode  17 = v                # v [U+0076] LATIN SMALL LETTER V
+shift   shiftr  keycode  17 = v                # v [U+0076] LATIN SMALL LETTER V
+        shiftl  keycode  17 = +V               # V [U+0056] LATIN CAPITAL LETTER V
+        shiftr  keycode  17 = +V               # V [U+0056] LATIN CAPITAL LETTER V
+        altgr   keycode  17 = underscore       # _ [U+005F] LOW LINE
+        ctrll   keycode  17 = BackSpace        #
+shiftl  ctrll   keycode  17 = BackSpace        #
+shiftr  ctrll   keycode  17 = BackSpace        #
+shiftl  altgr   keycode  17 = VoidSymbol       #
+shiftr  altgr   keycode  17 = VoidSymbol       #
+ctrll   altgr   keycode  17 = U+221a           # √ [U+221A] SQUARE ROOT
+
+                keycode  18 = l                # l [U+006C] LATIN SMALL LETTER L
+shift   shiftl  keycode  18 = l                # l [U+006C] LATIN SMALL LETTER L
+shift   shiftr  keycode  18 = l                # l [U+006C] LATIN SMALL LETTER L
+        shiftl  keycode  18 = +L               # L [U+004C] LATIN CAPITAL LETTER L
+        shiftr  keycode  18 = +L               # L [U+004C] LATIN CAPITAL LETTER L
+        altgr   keycode  18 = bracketleft      # [ [U+005B] LEFT SQUARE BRACKET
+        ctrll   keycode  18 = Up               #
+shiftl  ctrll   keycode  18 = Up               #
+shiftr  ctrll   keycode  18 = Up               #
+shiftl  altgr   keycode  18 = U+03bb           # λ [U+03BB] GREEK SMALL LETTER LAMDA
+shiftr  altgr   keycode  18 = U+03bb           # λ [U+03BB] GREEK SMALL LETTER LAMDA
+ctrll   altgr   keycode  18 = U+039b           # Λ [U+039B] GREEK CAPITAL LETTER LAMDA
+
+                keycode  19 = c                # c [U+0063] LATIN SMALL LETTER C
+shift   shiftl  keycode  19 = c                # c [U+0063] LATIN SMALL LETTER C
+shift   shiftr  keycode  19 = c                # c [U+0063] LATIN SMALL LETTER C
+        shiftl  keycode  19 = +C               # C [U+0043] LATIN CAPITAL LETTER C
+        shiftr  keycode  19 = +C               # C [U+0043] LATIN CAPITAL LETTER C
+        altgr   keycode  19 = bracketright     # ] [U+005D] RIGHT SQUARE BRACKET
+        ctrll   keycode  19 = Remove           #
+shiftl  ctrll   keycode  19 = Remove           #
+shiftr  ctrll   keycode  19 = Remove           #
+shiftl  altgr   keycode  19 = U+03c7           # χ [U+03C7] GREEK SMALL LETTER CHI
+shiftr  altgr   keycode  19 = U+03c7           # χ [U+03C7] GREEK SMALL LETTER CHI
+ctrll   altgr   keycode  19 = U+2102           # ℂ [U+2102] DOUBLE-STRUCK CAPITAL C
+
+                keycode  20 = w                # w [U+0077] LATIN SMALL LETTER W
+shift   shiftl  keycode  20 = w                # w [U+0077] LATIN SMALL LETTER W
+shift   shiftr  keycode  20 = w                # w [U+0077] LATIN SMALL LETTER W
+        shiftl  keycode  20 = +W               # W [U+0057] LATIN CAPITAL LETTER W
+        shiftr  keycode  20 = +W               # W [U+0057] LATIN CAPITAL LETTER W
+        altgr   keycode  20 = asciicircum      # ^ [U+005E] CIRCUMFLEX ACCENT
+        ctrll   keycode  20 = Next             #
+shiftl  ctrll   keycode  20 = Next             #
+shiftr  ctrll   keycode  20 = Next             #
+shiftl  altgr   keycode  20 = U+03c9           # ω [U+03C9] GREEK SMALL LETTER OMEGA
+shiftr  altgr   keycode  20 = U+03c9           # ω [U+03C9] GREEK SMALL LETTER OMEGA
+ctrll   altgr   keycode  20 = U+03a9           # Ω [U+03A9] GREEK CAPITAL LETTER OMEGA
+
+                keycode  21 = k                # k [U+006B] LATIN SMALL LETTER K
+shift   shiftl  keycode  21 = k                # k [U+006B] LATIN SMALL LETTER K
+shift   shiftr  keycode  21 = k                # k [U+006B] LATIN SMALL LETTER K
+        shiftl  keycode  21 = +K               # K [U+004B] LATIN CAPITAL LETTER K
+        shiftr  keycode  21 = +K               # K [U+004B] LATIN CAPITAL LETTER K
+        altgr   keycode  21 = exclam           # ! [U+0021] EXCLAMATION MARK
+        ctrll   keycode  21 = exclamdown       # ¡ [U+00A1] INVERTED EXCLAMATION MARK
+shiftl  ctrll   keycode  21 = exclamdown       # ¡ [U+00A1] INVERTED EXCLAMATION MARK
+shiftr  ctrll   keycode  21 = exclamdown       # ¡ [U+00A1] INVERTED EXCLAMATION MARK
+shiftl  altgr   keycode  21 = U+03ba           # κ [U+03BA] GREEK SMALL LETTER KAPPA
+shiftr  altgr   keycode  21 = U+03ba           # κ [U+03BA] GREEK SMALL LETTER KAPPA
+ctrll   altgr   keycode  21 = multiply         # × [U+00D7] MULTIPLICATION SIGN
+
+                keycode  22 = h                # h [U+0068] LATIN SMALL LETTER H
+shift   shiftl  keycode  22 = h                # h [U+0068] LATIN SMALL LETTER H
+shift   shiftr  keycode  22 = h                # h [U+0068] LATIN SMALL LETTER H
+        shiftl  keycode  22 = +H               # H [U+0048] LATIN CAPITAL LETTER H
+        shiftr  keycode  22 = +H               # H [U+0048] LATIN CAPITAL LETTER H
+        altgr   keycode  22 = less             # < [U+003C] LESS-THAN SIGN
+        ctrll   keycode  22 = seven            # 7 [U+0037] DIGIT SEVEN
+shiftl  ctrll   keycode  22 = seven            # 7 [U+0037] DIGIT SEVEN
+shiftr  ctrll   keycode  22 = seven            # 7 [U+0037] DIGIT SEVEN
+shiftl  altgr   keycode  22 = U+03c8           # ψ [U+03C8] GREEK SMALL LETTER PSI
+shiftr  altgr   keycode  22 = U+03c8           # ψ [U+03C8] GREEK SMALL LETTER PSI
+ctrll   altgr   keycode  22 = U+03a8           # Ψ [U+03A8] GREEK CAPITAL LETTER PSI
+
+                keycode  23 = g                # g [U+0067] LATIN SMALL LETTER G
+shift   shiftl  keycode  23 = g                # g [U+0067] LATIN SMALL LETTER G
+shift   shiftr  keycode  23 = g                # g [U+0067] LATIN SMALL LETTER G
+        shiftl  keycode  23 = +G               # G [U+0047] LATIN CAPITAL LETTER G
+        shiftr  keycode  23 = +G               # G [U+0047] LATIN CAPITAL LETTER G
+        altgr   keycode  23 = greater          # > [U+003E] GREATER-THAN SIGN
+        ctrll   keycode  23 = eight            # 8 [U+0038] DIGIT EIGHT
+shiftl  ctrll   keycode  23 = eight            # 8 [U+0038] DIGIT EIGHT
+shiftr  ctrll   keycode  23 = eight            # 8 [U+0038] DIGIT EIGHT
+shiftl  altgr   keycode  23 = U+03b3           # γ [U+03B3] GREEK SMALL LETTER GAMMA
+shiftr  altgr   keycode  23 = U+03b3           # γ [U+03B3] GREEK SMALL LETTER GAMMA
+ctrll   altgr   keycode  23 = U+0393           # Γ [U+0393] GREEK CAPITAL LETTER GAMMA
+
+                keycode  24 = f                # f [U+0066] LATIN SMALL LETTER F
+shift   shiftl  keycode  24 = f                # f [U+0066] LATIN SMALL LETTER F
+shift   shiftr  keycode  24 = f                # f [U+0066] LATIN SMALL LETTER F
+        shiftl  keycode  24 = +F               # F [U+0046] LATIN CAPITAL LETTER F
+        shiftr  keycode  24 = +F               # F [U+0046] LATIN CAPITAL LETTER F
+        altgr   keycode  24 = equal            # = [U+003D] EQUALS SIGN
+        ctrll   keycode  24 = nine             # 9 [U+0039] DIGIT NINE
+shiftl  ctrll   keycode  24 = nine             # 9 [U+0039] DIGIT NINE
+shiftr  ctrll   keycode  24 = nine             # 9 [U+0039] DIGIT NINE
+shiftl  altgr   keycode  24 = U+03c6           # φ [U+03C6] GREEK SMALL LETTER PHI
+shiftr  altgr   keycode  24 = U+03c6           # φ [U+03C6] GREEK SMALL LETTER PHI
+ctrll   altgr   keycode  24 = U+03a6           # Φ [U+03A6] GREEK CAPITAL LETTER PHI
+
+                keycode  25 = q                # q [U+0071] LATIN SMALL LETTER Q
+shift   shiftl  keycode  25 = q                # q [U+0071] LATIN SMALL LETTER Q
+shift   shiftr  keycode  25 = q                # q [U+0071] LATIN SMALL LETTER Q
+        shiftl  keycode  25 = +Q               # Q [U+0051] LATIN CAPITAL LETTER Q
+        shiftr  keycode  25 = +Q               # Q [U+0051] LATIN CAPITAL LETTER Q
+        altgr   keycode  25 = ampersand        # & [U+0026] AMPERSAND
+        ctrll   keycode  25 = plus             # + [U+002B] PLUS SIGN
+shiftl  ctrll   keycode  25 = plus             # + [U+002B] PLUS SIGN
+shiftr  ctrll   keycode  25 = plus             # + [U+002B] PLUS SIGN
+shiftl  altgr   keycode  25 = U+03d5           # ϕ [U+03D5] GREEK PHI SYMBOL
+shiftr  altgr   keycode  25 = U+03d5           # ϕ [U+03D5] GREEK PHI SYMBOL
+ctrll   altgr   keycode  25 = U+211a           # ℚ [U+211A] DOUBLE-STRUCK CAPITAL Q
+
+
+# Wrong CapsLock behaviour with ssharp, see:
+# https://bugzilla.kernel.org/show_bug.cgi?id=7063
+
+                keycode  26 = +ssharp          # ß [U+00DF] LATIN SMALL LETTER SHARP S
+        shift   keycode  26 = U+1e9e           # ẞ [U+1E9E] LATIN CAPITAL LETTER SHARP S
+        shiftl  keycode  26 = U+1e9e           # ẞ [U+1E9E] LATIN CAPITAL LETTER SHARP S
+        shiftr  keycode  26 = U+1e9e           # ẞ [U+1E9E] LATIN CAPITAL LETTER SHARP S
+        altgr   keycode  26 = U+017f           # ſ [U+017F] LATIN SMALL LETTER LONG S
+        ctrll   keycode  26 = U+2212           # − [U+2212] MINUS SIGN
+shiftl  ctrll   keycode  26 = U+2212           # − [U+2212] MINUS SIGN
+shiftr  ctrll   keycode  26 = U+2212           # − [U+2212] MINUS SIGN
+shiftl  altgr   keycode  26 = U+03c2           # ς [U+03C2] GREEK SMALL LETTER FINAL SIGMA
+shiftr  altgr   keycode  26 = U+03c2           # ς [U+03C2] GREEK SMALL LETTER FINAL SIGMA
+ctrll   altgr   keycode  26 = U+2218           # ∘ [U+2218] RING OPERATOR
+
+                keycode  30 = u                # u [U+0075] LATIN SMALL LETTER U
+shift   shiftl  keycode  30 = u                # u [U+0075] LATIN SMALL LETTER U
+shift   shiftr  keycode  30 = u                # u [U+0075] LATIN SMALL LETTER U
+        shiftl  keycode  30 = +U               # U [U+0055] LATIN CAPITAL LETTER U
+        shiftr  keycode  30 = +U               # U [U+0055] LATIN CAPITAL LETTER U
+        altgr   keycode  30 = backslash        # \ [U+005C] REVERSE SOLIDUS
+        ctrll   keycode  30 = Home             #
+shiftl  ctrll   keycode  30 = Home             #
+shiftr  ctrll   keycode  30 = Home             #
+shiftl  altgr   keycode  30 = VoidSymbol       #
+shiftr  altgr   keycode  30 = VoidSymbol       #
+ctrll   altgr   keycode  30 = U+2282           # ⊂ [U+2282] SUBSET OF
+
+                keycode  31 = i                # i [U+0069] LATIN SMALL LETTER I
+shift   shiftl  keycode  31 = i                # i [U+0069] LATIN SMALL LETTER I
+shift   shiftr  keycode  31 = i                # i [U+0069] LATIN SMALL LETTER I
+        shiftl  keycode  31 = +I               # I [U+0049] LATIN CAPITAL LETTER I
+        shiftr  keycode  31 = +I               # I [U+0049] LATIN CAPITAL LETTER I
+        altgr   keycode  31 = slash            # / [U+002F] SOLIDUS
+        ctrll   keycode  31 = Left             #
+shiftl  ctrll   keycode  31 = Left             #
+shiftr  ctrll   keycode  31 = Left             #
+shiftl  altgr   keycode  31 = U+03b9           # ι [U+03B9] GREEK SMALL LETTER IOTA
+shiftr  altgr   keycode  31 = U+03b9           # ι [U+03B9] GREEK SMALL LETTER IOTA
+ctrll   altgr   keycode  31 = U+222b           # ∫ [U+222B] INTEGRAL
+
+                keycode  32 = a                # a [U+0061] LATIN SMALL LETTER A
+shift   shiftl  keycode  32 = a                # a [U+0061] LATIN SMALL LETTER A
+shift   shiftr  keycode  32 = a                # a [U+0061] LATIN SMALL LETTER A
+        shiftl  keycode  32 = +A               # A [U+0041] LATIN CAPITAL LETTER A
+        shiftr  keycode  32 = +A               # A [U+0041] LATIN CAPITAL LETTER A
+        altgr   keycode  32 = braceleft        # { [U+007B] LEFT CURLY BRACKET
+        ctrll   keycode  32 = Down             #
+shiftl  ctrll   keycode  32 = Down             #
+shiftr  ctrll   keycode  32 = Down             #
+shiftl  altgr   keycode  32 = U+03b1           # α [U+03B1] GREEK SMALL LETTER ALPHA
+shiftr  altgr   keycode  32 = U+03b1           # α [U+03B1] GREEK SMALL LETTER ALPHA
+ctrll   altgr   keycode  32 = U+2200           # ∀ [U+2200] FOR ALL
+
+                keycode  33 = e                # e [U+0065] LATIN SMALL LETTER E
+shift   shiftl  keycode  33 = e                # e [U+0065] LATIN SMALL LETTER E
+shift   shiftr  keycode  33 = e                # e [U+0065] LATIN SMALL LETTER E
+        shiftl  keycode  33 = +E               # E [U+0045] LATIN CAPITAL LETTER E
+        shiftr  keycode  33 = +E               # E [U+0045] LATIN CAPITAL LETTER E
+        altgr   keycode  33 = braceright       # } [U+007D] RIGHT CURLY BRACKET
+        ctrll   keycode  33 = Right            #
+shiftl  ctrll   keycode  33 = Right            #
+shiftr  ctrll   keycode  33 = Right            #
+shiftl  altgr   keycode  33 = U+03b5           # ε [U+03B5] GREEK SMALL LETTER EPSILON
+shiftr  altgr   keycode  33 = U+03b5           # ε [U+03B5] GREEK SMALL LETTER EPSILON
+ctrll   altgr   keycode  33 = U+2203           # ∃ [U+2203] THERE EXISTS
+
+                keycode  34 = o                # o [U+006F] LATIN SMALL LETTER O
+shift   shiftl  keycode  34 = o                # o [U+006F] LATIN SMALL LETTER O
+shift   shiftr  keycode  34 = o                # o [U+006F] LATIN SMALL LETTER O
+        shiftl  keycode  34 = +O               # O [U+004F] LATIN CAPITAL LETTER O
+        shiftr  keycode  34 = +O               # O [U+004F] LATIN CAPITAL LETTER O
+        altgr   keycode  34 = asterisk         # * [U+002A] ASTERISK
+        ctrll   keycode  34 = End              #
+shiftl  ctrll   keycode  34 = End              #
+shiftr  ctrll   keycode  34 = End              #
+shiftl  altgr   keycode  34 = U+03bf           # ο [U+03BF] GREEK SMALL LETTER OMICRON
+shiftr  altgr   keycode  34 = U+03bf           # ο [U+03BF] GREEK SMALL LETTER OMICRON
+ctrll   altgr   keycode  34 = U+2208           # ∈ [U+2208] ELEMENT OF
+
+                keycode  35 = s                # s [U+0073] LATIN SMALL LETTER S
+shift   shiftl  keycode  35 = s                # s [U+0073] LATIN SMALL LETTER S
+shift   shiftr  keycode  35 = s                # s [U+0073] LATIN SMALL LETTER S
+        shiftl  keycode  35 = +S               # S [U+0053] LATIN CAPITAL LETTER S
+        shiftr  keycode  35 = +S               # S [U+0053] LATIN CAPITAL LETTER S
+        altgr   keycode  35 = question         # ? [U+003F] QUESTION MARK
+        ctrll   keycode  35 = questiondown     # ¿ [U+00BF] INVERTED QUESTION MARK
+shiftl  ctrll   keycode  35 = questiondown     # ¿ [U+00BF] INVERTED QUESTION MARK
+shiftr  ctrll   keycode  35 = questiondown     # ¿ [U+00BF] INVERTED QUESTION MARK
+shiftl  altgr   keycode  35 = U+03c3           # σ [U+03C3] GREEK SMALL LETTER SIGMA
+shiftr  altgr   keycode  35 = U+03c3           # σ [U+03C3] GREEK SMALL LETTER SIGMA
+ctrll   altgr   keycode  35 = U+03a3           # Σ [U+03A3] GREEK CAPITAL LETTER SIGMA
+
+                keycode  36 = n                # n [U+006E] LATIN SMALL LETTER N
+shift   shiftl  keycode  36 = n                # n [U+006E] LATIN SMALL LETTER N
+shift   shiftr  keycode  36 = n                # n [U+006E] LATIN SMALL LETTER N
+        shiftl  keycode  36 = +N               # N [U+004E] LATIN CAPITAL LETTER N
+        shiftr  keycode  36 = +N               # N [U+004E] LATIN CAPITAL LETTER N
+        altgr   keycode  36 = parenleft        # ( [U+0028] LEFT PARENTHESIS
+        ctrll   keycode  36 = four             # 4 [U+0034] DIGIT FOUR
+shiftl  ctrll   keycode  36 = four             # 4 [U+0034] DIGIT FOUR
+shiftr  ctrll   keycode  36 = four             # 4 [U+0034] DIGIT FOUR
+shiftl  altgr   keycode  36 = U+03bd           # ν [U+03BD] GREEK SMALL LETTER NU
+shiftr  altgr   keycode  36 = U+03bd           # ν [U+03BD] GREEK SMALL LETTER NU
+ctrll   altgr   keycode  36 = U+2115           # ℕ [U+2115] DOUBLE-STRUCK CAPITAL N
+
+                keycode  37 = r                # r [U+0072] LATIN SMALL LETTER R
+shift   shiftl  keycode  37 = r                # r [U+0072] LATIN SMALL LETTER R
+shift   shiftr  keycode  37 = r                # r [U+0072] LATIN SMALL LETTER R
+        shiftl  keycode  37 = +R               # R [U+0052] LATIN CAPITAL LETTER R
+        shiftr  keycode  37 = +R               # R [U+0052] LATIN CAPITAL LETTER R
+        altgr   keycode  37 = parenright       # ) [U+0029] RIGHT PARENTHESIS
+        ctrll   keycode  37 = five             # 5 [U+0035] DIGIT FIVE
+shiftl  ctrll   keycode  37 = five             # 5 [U+0035] DIGIT FIVE
+shiftr  ctrll   keycode  37 = five             # 5 [U+0035] DIGIT FIVE
+shiftl  altgr   keycode  37 = U+03c1           # ρ [U+03C1] GREEK SMALL LETTER RHO
+shiftr  altgr   keycode  37 = U+03c1           # ρ [U+03C1] GREEK SMALL LETTER RHO
+ctrll   altgr   keycode  37 = U+211d           # ℝ [U+211D] DOUBLE-STRUCK CAPITAL R
+
+                keycode  38 = t                # t [U+0074] LATIN SMALL LETTER T
+shift   shiftl  keycode  38 = t                # t [U+0074] LATIN SMALL LETTER T
+shift   shiftr  keycode  38 = t                # t [U+0074] LATIN SMALL LETTER T
+        shiftl  keycode  38 = +T               # T [U+0054] LATIN CAPITAL LETTER T
+        shiftr  keycode  38 = +T               # T [U+0054] LATIN CAPITAL LETTER T
+        altgr   keycode  38 = minus            # - [U+002D] HYPHEN-MINUS
+        ctrll   keycode  38 = six              # 6 [U+0036] DIGIT SIX
+shiftl  ctrll   keycode  38 = six              # 6 [U+0036] DIGIT SIX
+shiftr  ctrll   keycode  38 = six              # 6 [U+0036] DIGIT SIX
+shiftl  altgr   keycode  38 = U+03c4           # τ [U+03C4] GREEK SMALL LETTER TAU
+shiftr  altgr   keycode  38 = U+03c4           # τ [U+03C4] GREEK SMALL LETTER TAU
+ctrll   altgr   keycode  38 = U+2202           # ∂ [U+2202] PARTIAL DIFFERENTIAL
+
+                keycode  39 = d                # d [U+0064] LATIN SMALL LETTER D
+shift   shiftl  keycode  39 = d                # d [U+0064] LATIN SMALL LETTER D
+shift   shiftr  keycode  39 = d                # d [U+0064] LATIN SMALL LETTER D
+        shiftl  keycode  39 = +D               # D [U+0044] LATIN CAPITAL LETTER D
+        shiftr  keycode  39 = +D               # D [U+0044] LATIN CAPITAL LETTER D
+        altgr   keycode  39 = colon            # : [U+003A] COLON
+        ctrll   keycode  39 = comma            # , [U+002C] COMMA
+shiftl  ctrll   keycode  39 = comma            # , [U+002C] COMMA
+shiftr  ctrll   keycode  39 = comma            # , [U+002C] COMMA
+shiftl  altgr   keycode  39 = U+03b4           # δ [U+03B4] GREEK SMALL LETTER DELTA
+shiftr  altgr   keycode  39 = U+03b4           # δ [U+03B4] GREEK SMALL LETTER DELTA
+ctrll   altgr   keycode  39 = U+0394           # Δ [U+0394] GREEK CAPITAL LETTER DELTA
+
+                keycode  40 = y                # y [U+0079] LATIN SMALL LETTER Y
+shift   shiftl  keycode  40 = y                # y [U+0079] LATIN SMALL LETTER Y
+shift   shiftr  keycode  40 = y                # y [U+0079] LATIN SMALL LETTER Y
+        shiftl  keycode  40 = +Y               # Y [U+0059] LATIN CAPITAL LETTER Y
+        shiftr  keycode  40 = +Y               # Y [U+0059] LATIN CAPITAL LETTER Y
+        altgr   keycode  40 = at               # @ [U+0040] COMMERCIAL AT
+        ctrll   keycode  40 = period           # . [U+002E] FULL STOP
+shiftl  ctrll   keycode  40 = period           # . [U+002E] FULL STOP
+shiftr  ctrll   keycode  40 = period           # . [U+002E] FULL STOP
+shiftl  altgr   keycode  40 = U+03c5           # υ [U+03C5] GREEK SMALL LETTER UPSILON
+shiftr  altgr   keycode  40 = U+03c5           # υ [U+03C5] GREEK SMALL LETTER UPSILON
+ctrll   altgr   keycode  40 = U+2207           # ∇ [U+2207] NABLA
+
+                keycode  44 = udiaeresis       # ü [U+00FC] LATIN SMALL LETTER U WITH DIAERESIS
+shift   shiftl  keycode  44 = udiaeresis       # ü [U+00FC] LATIN SMALL LETTER U WITH DIAERESIS
+shift   shiftr  keycode  44 = udiaeresis       # ü [U+00FC] LATIN SMALL LETTER U WITH DIAERESIS
+        shiftl  keycode  44 = +Udiaeresis      # Ü [U+00DC] LATIN CAPITAL LETTER U WITH DIAERESIS
+        shiftr  keycode  44 = +Udiaeresis      # Ü [U+00DC] LATIN CAPITAL LETTER U WITH DIAERESIS
+        altgr   keycode  44 = numbersign       # # [U+0023] NUMBER SIGN
+        ctrll   keycode  44 = Escape           #
+shiftl  ctrll   keycode  44 = Escape           #
+shiftr  ctrll   keycode  44 = Escape           #
+shiftl  altgr   keycode  44 = VoidSymbol       #
+shiftr  altgr   keycode  44 = VoidSymbol       #
+ctrll   altgr   keycode  44 = U+222a           # ∪ [U+222A] UNION
+
+                keycode  45 = odiaeresis       # ö [U+00F6] LATIN SMALL LETTER O WITH DIAERESIS
+shift   shiftl  keycode  45 = odiaeresis       # ö [U+00F6] LATIN SMALL LETTER O WITH DIAERESIS
+shift   shiftr  keycode  45 = odiaeresis       # ö [U+00F6] LATIN SMALL LETTER O WITH DIAERESIS
+        shiftl  keycode  45 = +Odiaeresis      # Ö [U+00D6] LATIN CAPITAL LETTER O WITH DIAERESIS
+        shiftr  keycode  45 = +Odiaeresis      # Ö [U+00D6] LATIN CAPITAL LETTER O WITH DIAERESIS
+        altgr   keycode  45 = dollar           # $ [U+0024] DOLLAR SIGN
+        ctrll   keycode  45 = Tab              #
+shiftl  ctrll   keycode  45 = Tab              #
+shiftr  ctrll   keycode  45 = Tab              #
+shiftl  altgr   keycode  45 = U+03f5           # ϵ [U+03F5] GREEK LUNATE EPSILON SYMBOL
+shiftr  altgr   keycode  45 = U+03f5           # ϵ [U+03F5] GREEK LUNATE EPSILON SYMBOL
+ctrll   altgr   keycode  45 = U+2229           # ∩ [U+2229] INTERSECTION
+
+                keycode  46 = adiaeresis       # ä [U+00E4] LATIN SMALL LETTER A WITH DIAERESIS
+shift   shiftl  keycode  46 = adiaeresis       # ä [U+00E4] LATIN SMALL LETTER A WITH DIAERESIS
+shift   shiftr  keycode  46 = adiaeresis       # ä [U+00E4] LATIN SMALL LETTER A WITH DIAERESIS
+        shiftl  keycode  46 = +Adiaeresis      # Ä [U+00C4] LATIN CAPITAL LETTER A WITH DIAERESIS
+        shiftr  keycode  46 = +Adiaeresis      # Ä [U+00C4] LATIN CAPITAL LETTER A WITH DIAERESIS
+        altgr   keycode  46 = bar              # | [U+007C] VERTICAL LINE
+        ctrll   keycode  46 = Insert           #
+shiftl  ctrll   keycode  46 = Insert           #
+shiftr  ctrll   keycode  46 = Insert           #
+shiftl  altgr   keycode  46 = U+03b7           # η [U+03B7] GREEK SMALL LETTER ETA
+shiftr  altgr   keycode  46 = U+03b7           # η [U+03B7] GREEK SMALL LETTER ETA
+ctrll   altgr   keycode  46 = U+2135           # ℵ [U+2135] ALEF SYMBOL
+
+                keycode  47 = p                # p [U+0070] LATIN SMALL LETTER P
+shift   shiftl  keycode  47 = p                # p [U+0070] LATIN SMALL LETTER P
+shift   shiftr  keycode  47 = p                # p [U+0070] LATIN SMALL LETTER P
+        shiftl  keycode  47 = +P               # P [U+0050] LATIN CAPITAL LETTER P
+        shiftr  keycode  47 = +P               # P [U+0050] LATIN CAPITAL LETTER P
+        altgr   keycode  47 = asciitilde       # ~ [U+007E] TILDE
+        ctrll   keycode  47 = Return           #
+shiftl  ctrll   keycode  47 = Return           #
+shiftr  ctrll   keycode  47 = Return           #
+shiftl  altgr   keycode  47 = U+03c0           # π [U+03C0] GREEK SMALL LETTER PI
+shiftr  altgr   keycode  47 = U+03c0           # π [U+03C0] GREEK SMALL LETTER PI
+ctrll   altgr   keycode  47 = U+03a0           # Π [U+03A0] GREEK CAPITAL LETTER PI
+
+                keycode  48 = z                # z [U+007A] LATIN SMALL LETTER Z
+shift   shiftl  keycode  48 = z                # z [U+007A] LATIN SMALL LETTER Z
+shift   shiftr  keycode  48 = z                # z [U+007A] LATIN SMALL LETTER Z
+        shiftl  keycode  48 = +Z               # Z [U+005A] LATIN CAPITAL LETTER Z
+        shiftr  keycode  48 = +Z               # Z [U+005A] LATIN CAPITAL LETTER Z
+        altgr   keycode  48 = grave            # ` [U+0060] GRAVE ACCENT
+        ctrll   keycode  48 = VoidSymbol       #
+shiftl  ctrll   keycode  48 = VoidSymbol       #
+shiftr  ctrll   keycode  48 = VoidSymbol       #
+shiftl  altgr   keycode  48 = U+03b6           # ζ [U+03B6] GREEK SMALL LETTER ZETA
+shiftr  altgr   keycode  48 = U+03b6           # ζ [U+03B6] GREEK SMALL LETTER ZETA
+ctrll   altgr   keycode  48 = U+2124           # ℤ [U+2124] DOUBLE-STRUCK CAPITAL Z
+
+                keycode  49 = b                # b [U+0062] LATIN SMALL LETTER B
+shift   shiftl  keycode  49 = b                # b [U+0062] LATIN SMALL LETTER B
+shift   shiftr  keycode  49 = b                # b [U+0062] LATIN SMALL LETTER B
+        shiftl  keycode  49 = +B               # B [U+0042] LATIN CAPITAL LETTER B
+        shiftr  keycode  49 = +B               # B [U+0042] LATIN CAPITAL LETTER B
+        altgr   keycode  49 = plus             # + [U+002B] PLUS SIGN
+        ctrll   keycode  49 = colon            # : [U+003A] COLON
+shiftl  ctrll   keycode  49 = colon            # : [U+003A] COLON
+shiftr  ctrll   keycode  49 = colon            # : [U+003A] COLON
+shiftl  altgr   keycode  49 = U+03b2           # β [U+03B2] GREEK SMALL LETTER BETA
+shiftr  altgr   keycode  49 = U+03b2           # β [U+03B2] GREEK SMALL LETTER BETA
+ctrll   altgr   keycode  49 = U+21d0           # ⇐ [U+21D0] LEFTWARDS DOUBLE ARROW
+
+                keycode  50 = m                # m [U+006D] LATIN SMALL LETTER M
+shift   shiftl  keycode  50 = m                # m [U+006D] LATIN SMALL LETTER M
+shift   shiftr  keycode  50 = m                # m [U+006D] LATIN SMALL LETTER M
+        shiftl  keycode  50 = +M               # M [U+004D] LATIN CAPITAL LETTER M
+        shiftr  keycode  50 = +M               # M [U+004D] LATIN CAPITAL LETTER M
+        altgr   keycode  50 = percent          # % [U+0025] PERCENT SIGN
+        ctrll   keycode  50 = one              # 1 [U+0031] DIGIT ONE
+shiftl  ctrll   keycode  50 = one              # 1 [U+0031] DIGIT ONE
+shiftr  ctrll   keycode  50 = one              # 1 [U+0031] DIGIT ONE
+shiftl  altgr   keycode  50 = U+03bc           # μ [U+03BC] GREEK SMALL LETTER MU
+shiftr  altgr   keycode  50 = U+03bc           # μ [U+03BC] GREEK SMALL LETTER MU
+ctrll   altgr   keycode  50 = U+21d4           # ⇔ [U+21D4] LEFT RIGHT DOUBLE ARROW
+
+                keycode  51 = comma            # , [U+002C] COMMA
+        shiftl  keycode  51 = U+2013           # – [U+2013] EN DASH
+        shiftr  keycode  51 = U+2013           # – [U+2013] EN DASH
+        altgr   keycode  51 = quotedbl         # " [U+0022] QUOTATION MARK
+        ctrll   keycode  51 = two              # 2 [U+0032] DIGIT TWO
+shiftl  ctrll   keycode  51 = two              # 2 [U+0032] DIGIT TWO
+shiftr  ctrll   keycode  51 = two              # 2 [U+0032] DIGIT TWO
+shiftl  altgr   keycode  51 = U+03f1           # ϱ [U+03F1] GREEK RHO SYMBOL
+shiftr  altgr   keycode  51 = U+03f1           # ϱ [U+03F1] GREEK RHO SYMBOL
+ctrll   altgr   keycode  51 = U+21d2           # ⇒ [U+21D2] RIGHTWARDS DOUBLE ARROW
+
+                keycode  52 = period           # . [U+002E] FULL STOP
+        shiftl  keycode  52 = U+2022           # • [U+2022] BULLET
+        shiftr  keycode  52 = U+2022           # • [U+2022] BULLET
+        altgr   keycode  52 = apostrophe       # ' [U+0027] APOSTROPHE
+        ctrll   keycode  52 = three            # 3 [U+0033] DIGIT THREE
+shiftl  ctrll   keycode  52 = three            # 3 [U+0033] DIGIT THREE
+shiftr  ctrll   keycode  52 = three            # 3 [U+0033] DIGIT THREE
+shiftl  altgr   keycode  52 = U+03d1           # ϑ [U+03D1] GREEK THETA SYMBOL
+shiftr  altgr   keycode  52 = U+03d1           # ϑ [U+03D1] GREEK THETA SYMBOL
+ctrll   altgr   keycode  52 = U+21a6           # ↦ [U+21A6] RIGHTWARDS ARROW FROM BAR
+
+                keycode  53 = j                # j [U+006A] LATIN SMALL LETTER J
+shift   shiftl  keycode  53 = j                # j [U+006A] LATIN SMALL LETTER J
+shift   shiftr  keycode  53 = j                # j [U+006A] LATIN SMALL LETTER J
+        shiftl  keycode  53 = +J               # J [U+004A] LATIN CAPITAL LETTER J
+        shiftr  keycode  53 = +J               # J [U+004A] LATIN CAPITAL LETTER J
+        altgr   keycode  53 = semicolon        # ; [U+003B] SEMICOLON
+        ctrll   keycode  53 = semicolon        # ; [U+003B] SEMICOLON
+shiftl  ctrll   keycode  53 = semicolon        # ; [U+003B] SEMICOLON
+shiftr  ctrll   keycode  53 = semicolon        # ; [U+003B] SEMICOLON
+shiftl  altgr   keycode  53 = U+03b8           # θ [U+03B8] GREEK SMALL LETTER THETA
+shiftr  altgr   keycode  53 = U+03b8           # θ [U+03B8] GREEK SMALL LETTER THETA
+ctrll   altgr   keycode  53 = U+0398           # Θ [U+0398] GREEK CAPITAL LETTER THETA
+
+#==========================================================================
+# Special Character Keys
+#==========================================================================
+
+                keycode  57 = space            #   [U+0020] SPACE
+        ctrll   keycode  57 = zero             # 0 [U+0030] DIGIT ZERO
+shiftl  ctrll   keycode  57 = zero             # 0 [U+0030] DIGIT ZERO
+shiftr  ctrll   keycode  57 = zero             # 0 [U+0030] DIGIT ZERO
+shiftl  altgr   keycode  57 = nobreakspace     #   [U+02DE] NO-BREAK SPACE
+shiftr  altgr   keycode  57 = nobreakspace     #   [U+02DE] NO-BREAK SPACE
+ctrll   altgr   keycode  57 = U+202F           #   [U+202F] NARROW NO-BREAK SPACE
+
+                keycode  41 = dead_circumflex  #
+        shiftl  keycode  41 = U+02c7           # ˇ [U+02C7] CARON
+        shiftr  keycode  41 = U+02c7           # ˇ [U+02C7] CARON
+        altgr   keycode  41 = U+21bb           # ↻ [U+21BB] CLOCKWISE OPEN CIRCLE ARROW
+        ctrll   keycode  41 = U+02d9           # ˙ [U+02D9] DOT ABOVE
+shiftl  ctrll   keycode  41 = U+02d9           # ˙ [U+02D9] DOT ABOVE
+shiftr  ctrll   keycode  41 = U+02d9           # ˙ [U+02D9] DOT ABOVE
+shiftl  altgr   keycode  41 = U+02de           # ˞ [U+02DE] MODIFIER LETTER RHOTIC HOOK
+shiftr  altgr   keycode  41 = U+02de           # ˞ [U+02DE] MODIFIER LETTER RHOTIC HOOK
+ctrll   altgr   keycode  41 = period           # . [U+002E] FULL STOP
+
+                keycode  13 = dead_grave       #
+        shiftl  keycode  13 = dead_cedilla     #
+        shiftr  keycode  13 = dead_cedilla     #
+        altgr   keycode  13 = U+02da           # ˚ [U+02DA] RING ABOVE
+        ctrll   keycode  13 = dead_diaeresis   #
+shiftl  ctrll   keycode  13 = dead_diaeresis   #
+shiftr  ctrll   keycode  13 = dead_diaeresis   #
+shiftl  altgr   keycode  13 = U+1ffe           # ῾ [U+1FFE] GREEK DASIA
+shiftr  altgr   keycode  13 = U+1ffe           # ῾ [U+1FFE] GREEK DASIA
+ctrll   altgr   keycode  13 = macron           # ¯ [U+00AF] MACRON
+
+                keycode  27 = dead_acute       #
+        shiftl  keycode  27 = dead_tilde       #
+        shiftr  keycode  27 = dead_tilde       #
+        altgr   keycode  27 = slash            # / [U+002F] SOLIDUS
+        ctrll   keycode  27 = U+02dd           # ˝ [U+02DD] DOUBLE ACUTE ACCENT
+shiftl  ctrll   keycode  27 = U+02dd           # ˝ [U+02DD] DOUBLE ACUTE ACCENT
+shiftr  ctrll   keycode  27 = U+02dd           # ˝ [U+02DD] DOUBLE ACUTE ACCENT
+shiftl  altgr   keycode  27 = U+1fbf           # ᾿ [U+1FBF] GREEK PSILI
+shiftr  altgr   keycode  27 = U+1fbf           # ᾿ [U+1FBF] GREEK PSILI
+ctrll   altgr   keycode  27 = U+02d8           # ˘ [U+02D8] BREVE
+
+#==========================================================================
+# Keypad
+#==========================================================================
+
+                keycode  69 = Tab              #
+        shiftl  keycode  69 = Tab              #
+        shiftr  keycode  69 = Tab              #
+        altgr   keycode  69 = equal            # = [U+003D] EQUALS SIGN
+        ctrll   keycode  69 = U+2260           # ≠ [U+2260] NOT EQUAL TO
+shiftl  ctrll   keycode  69 = U+2260           # ≠ [U+2260] NOT EQUAL TO
+shiftr  ctrll   keycode  69 = U+2260           # ≠ [U+2260] NOT EQUAL TO
+shiftl  altgr   keycode  69 = U+2248           # ≈ [U+2248] ALMOST EQUAL TO
+shiftr  altgr   keycode  69 = U+2248           # ≈ [U+2248] ALMOST EQUAL TO
+ctrll   altgr   keycode  69 = U+2261           # ≡ [U+2261] IDENTICAL TO
+
+                keycode  98 = KP_Divide        # / [U+002F] SOLIDUS
+        shiftl  keycode  98 = KP_Divide        # / [U+002F] SOLIDUS
+        shiftr  keycode  98 = KP_Divide        # / [U+002F] SOLIDUS
+        altgr   keycode  98 = division         # ÷ [U+00F7] DIVISION SIGN
+        ctrll   keycode  98 = U+2044           # ⁄ [U+2044] FRACTION SLASH
+shiftl  ctrll   keycode  98 = U+2044           # ⁄ [U+2044] FRACTION SLASH
+shiftr  ctrll   keycode  98 = U+2044           # ⁄ [U+2044] FRACTION SLASH
+shiftl  altgr   keycode  98 = U+2300           # ⌀ [U+2300] DIAMETER SIGN
+shiftr  altgr   keycode  98 = U+2300           # ⌀ [U+2300] DIAMETER SIGN
+ctrll   altgr   keycode  98 = U+2223           # ∣ [U+2223] DIVIDES
+
+                keycode  55 = KP_Multiply      # * [U+002A] ASTERISK
+        shiftl  keycode  55 = KP_Multiply      # * [U+002A] ASTERISK
+        shiftr  keycode  55 = KP_Multiply      # * [U+002A] ASTERISK
+        altgr   keycode  55 = U+22c5           # ⋅ [U+22C5] DOT OPERATOR
+        ctrll   keycode  55 = multiply         # × [U+00D7] MULTIPLICATION SIGN
+shiftl  ctrll   keycode  55 = multiply         # × [U+00D7] MULTIPLICATION SIGN
+shiftr  ctrll   keycode  55 = multiply         # × [U+00D7] MULTIPLICATION SIGN
+shiftl  altgr   keycode  55 = U+2299           # ⊙ [U+2299] CIRCLED DOT OPERATOR
+shiftr  altgr   keycode  55 = U+2299           # ⊙ [U+2299] CIRCLED DOT OPERATOR
+ctrll   altgr   keycode  55 = U+2297           # ⊗ [U+2297] CIRCLED TIMES
+
+                keycode  74 = KP_Subtract      # - [U+002D] HYPHEN-MINUS
+        shiftl  keycode  74 = KP_Subtract      # - [U+002D] HYPHEN-MINUS
+        shiftr  keycode  74 = KP_Subtract      # - [U+002D] HYPHEN-MINUS
+        altgr   keycode  74 = U+2212           # − [U+2212] MINUS SIGN
+        ctrll   keycode  74 = U+2216           # ∖ [U+2216] SET MINUS
+shiftl  ctrll   keycode  74 = U+2216           # ∖ [U+2216] SET MINUS
+shiftr  ctrll   keycode  74 = U+2216           # ∖ [U+2216] SET MINUS
+shiftl  altgr   keycode  74 = U+2296           # ⊖ [U+2296] CIRCLED MINUS
+shiftr  altgr   keycode  74 = U+2296           # ⊖ [U+2296] CIRCLED MINUS
+ctrll   altgr   keycode  74 = U+2238           # ∸ [U+2238] DOT MINUS
+
+                keycode  71 = KP_7             # 7 [U+0037] DIGIT SEVEN
+        shiftl  keycode  71 = U+2714           # ✔ [U+2714] HEAVY CHECK MARK
+        shiftr  keycode  71 = U+2714           # ✔ [U+2714] HEAVY CHECK MARK
+        altgr   keycode  71 = U+2195           # ↕ [U+2195] UP DOWN ARROW
+        ctrll   keycode  71 = Home             #
+shiftl  ctrll   keycode  71 = Home             #
+shiftr  ctrll   keycode  71 = Home             #
+shiftl  altgr   keycode  71 = U+226a           # ≪ [U+226A] MUCH LESS-THAN
+shiftr  altgr   keycode  71 = U+226a           # ≪ [U+226A] MUCH LESS-THAN
+ctrll   altgr   keycode  71 = U+2308           # ⌈ [U+2308] LEFT CEILING
+
+                keycode  72 = KP_8             # 8 [U+0038] DIGIT EIGHT
+        shiftl  keycode  72 = U+2718           # ✘ [U+2718] HEAVY BALLOT X
+        shiftr  keycode  72 = U+2718           # ✘ [U+2718] HEAVY BALLOT X
+        altgr   keycode  72 = U+2191           # ↑ [U+2191] UPWARDS ARROW
+        ctrll   keycode  72 = Up               #
+shiftl  ctrll   keycode  72 = Up               #
+shiftr  ctrll   keycode  72 = Up               #
+shiftl  altgr   keycode  72 = U+2229           # ∩ [U+2229] INTERSECTION
+shiftr  altgr   keycode  72 = U+2229           # ∩ [U+2229] INTERSECTION
+ctrll   altgr   keycode  72 = U+22c2           # ⋂ [U+22C2] N-ARY INTERSECTION
+
+                keycode  73 = KP_9             # 9 [U+0039] DIGIT NINE
+        shiftl  keycode  73 = U+2020           # † [U+2020] DAGGER
+        shiftr  keycode  73 = U+2020           # † [U+2020] DAGGER
+        altgr   keycode  73 = VoidSymbol       #
+        ctrll   keycode  73 = Prior            #
+shiftl  ctrll   keycode  73 = Prior            #
+shiftr  ctrll   keycode  73 = Prior            #
+shiftl  altgr   keycode  73 = U+226b           # ≫ [U+226B] MUCH GREATER-THAN
+shiftr  altgr   keycode  73 = U+226b           # ≫ [U+226B] MUCH GREATER-THAN
+ctrll   altgr   keycode  73 = U+2309           # ⌉ [U+2309] RIGHT CEILING
+
+                keycode  75 = KP_4             # 4 [U+0034] DIGIT FOUR
+        shiftl  keycode  75 = U+2663           # ♣ [U+2663] BLACK CLUB SUIT
+        shiftr  keycode  75 = U+2663           # ♣ [U+2663] BLACK CLUB SUIT
+        altgr   keycode  75 = U+2190           # ← [U+2190] LEFTWARDS ARROW
+        ctrll   keycode  75 = Left             #
+shiftl  ctrll   keycode  75 = Left             #
+shiftr  ctrll   keycode  75 = Left             #
+shiftl  altgr   keycode  75 = U+2282           # ⊂ [U+2282] SUBSET OF
+shiftr  altgr   keycode  75 = U+2282           # ⊂ [U+2282] SUBSET OF
+ctrll   altgr   keycode  75 = U+2286           # ⊆ [U+2286] SUBSET OF OR EQUAL TO
+
+                keycode  76 = KP_5             # 5 [U+0035] DIGIT FIVE
+        shiftl  keycode  76 = U+20ac           # € [U+20AC] EURO SIGN
+        shiftr  keycode  76 = U+20ac           # € [U+20AC] EURO SIGN
+        altgr   keycode  76 = colon            # : [U+003A] COLON
+        ctrll   keycode  76 = VoidSymbol       #
+shiftl  ctrll   keycode  76 = VoidSymbol       #
+shiftr  ctrll   keycode  76 = VoidSymbol       #
+shiftl  altgr   keycode  76 = U+22b6           # ⊶ [U+22B6] ORIGINAL OF
+shiftr  altgr   keycode  76 = U+22b6           # ⊶ [U+22B6] ORIGINAL OF
+ctrll   altgr   keycode  76 = U+22b7           # ⊷ [U+22B7] IMAGE OF
+
+                keycode  77 = KP_6             # 6 [U+0036] DIGIT SIX
+        shiftl  keycode  77 = U+2023           # ‣ [U+2023] TRIANGULAR BULLET
+        shiftr  keycode  77 = U+2023           # ‣ [U+2023] TRIANGULAR BULLET
+        altgr   keycode  77 = U+2192           # → [U+2192] RIGHTWARDS ARROW
+        ctrll   keycode  77 = Right            #
+shiftl  ctrll   keycode  77 = Right            #
+shiftr  ctrll   keycode  77 = Right            #
+shiftl  altgr   keycode  77 = U+2283           # ⊃ [U+2283] SUPERSET OF
+shiftr  altgr   keycode  77 = U+2283           # ⊃ [U+2283] SUPERSET OF
+ctrll   altgr   keycode  77 = U+2287           # ⊇ [U+2287] SUPERSET OF OR EQUAL TO
+
+                keycode  78 = KP_Add           # + [U+002B] PLUS SIGN
+        shiftl  keycode  78 = KP_Add           # + [U+002B] PLUS SIGN
+        shiftr  keycode  78 = KP_Add           # + [U+002B] PLUS SIGN
+        altgr   keycode  78 = plusminus        # ± [U+00B1] PLUS-MINUS SIGN
+        ctrll   keycode  78 = U+2213           # ∓ [U+2213] MINUS-OR-PLUS SIGN
+shiftl  ctrll   keycode  78 = U+2213           # ∓ [U+2213] MINUS-OR-PLUS SIGN
+shiftr  ctrll   keycode  78 = U+2213           # ∓ [U+2213] MINUS-OR-PLUS SIGN
+shiftl  altgr   keycode  78 = U+2295           # ⊕ [U+2295] CIRCLED PLUS
+shiftr  altgr   keycode  78 = U+2295           # ⊕ [U+2295] CIRCLED PLUS
+ctrll   altgr   keycode  78 = U+2214           # ∔ [U+2214] DOT PLUS
+
+                keycode  79 = KP_1             # 1 [U+0031] DIGIT ONE
+        shiftl  keycode  79 = U+2666           # ♦ [U+2666] BLACK DIAMOND SUIT
+        shiftr  keycode  79 = U+2666           # ♦ [U+2666] BLACK DIAMOND SUIT
+        altgr   keycode  79 = U+2194           # ↔ [U+2194] LEFT RIGHT ARROW
+        ctrll   keycode  79 = End              #
+shiftl  ctrll   keycode  79 = End              #
+shiftr  ctrll   keycode  79 = End              #
+shiftl  altgr   keycode  79 = U+2264           # ≤ [U+2264] LESS-THAN OR EQUAL TO
+shiftr  altgr   keycode  79 = U+2264           # ≤ [U+2264] LESS-THAN OR EQUAL TO
+ctrll   altgr   keycode  79 = U+230a           # ⌊ [U+230A] LEFT FLOOR
+
+                keycode  80 = KP_2             # 2 [U+0032] DIGIT TWO
+        shiftl  keycode  80 = U+2665           # ♥ [U+2665] BLACK HEART SUIT
+        shiftr  keycode  80 = U+2665           # ♥ [U+2665] BLACK HEART SUIT
+        altgr   keycode  80 = U+2193           # ↓ [U+2193] DOWNWARDS ARROW
+        ctrll   keycode  80 = Down             #
+shiftl  ctrll   keycode  80 = Down             #
+shiftr  ctrll   keycode  80 = Down             #
+shiftl  altgr   keycode  80 = U+222a           # ∪ [U+222A] UNION
+shiftr  altgr   keycode  80 = U+222a           # ∪ [U+222A] UNION
+ctrll   altgr   keycode  80 = U+22c3           # ⋃ [U+22C3] N-ARY UNION
+
+                keycode  81 = KP_3             # 3 [U+0033] DIGIT THREE
+        shiftl  keycode  81 = U+2660           # ♠ [U+2660] BLACK SPADE SUIT
+        shiftr  keycode  81 = U+2660           # ♠ [U+2660] BLACK SPADE SUIT
+        altgr   keycode  81 = U+21cc           # ⇌ [U+21CC] RIGHTWARDS HARPOON OVER LEFTWARDS HARPOON
+        ctrll   keycode  81 = Next             #
+shiftl  ctrll   keycode  81 = Next             #
+shiftr  ctrll   keycode  81 = Next             #
+shiftl  altgr   keycode  81 = U+2265           # ≥ [U+2265] GREATER-THAN OR EQUAL TO
+shiftr  altgr   keycode  81 = U+2265           # ≥ [U+2265] GREATER-THAN OR EQUAL TO
+ctrll   altgr   keycode  81 = U+230b           # ⌋ [U+230B] RIGHT FLOOR
+
+                keycode  82 = KP_0             # 0 [U+0030] DIGIT ZERO
+        shiftl  keycode  82 = U+2423           # ␣ [U+2423] OPEN BOX
+        shiftr  keycode  82 = U+2423           # ␣ [U+2423] OPEN BOX
+        altgr   keycode  82 = percent          # % [U+0025] PERCENT SIGN
+        ctrll   keycode  82 = Insert           #
+shiftl  ctrll   keycode  82 = Insert           #
+shiftr  ctrll   keycode  82 = Insert           #
+shiftl  altgr   keycode  82 = U+2030           # ‰ [U+2030] PER MILLE SIGN
+shiftr  altgr   keycode  82 = U+2030           # ‰ [U+2030] PER MILLE SIGN
+ctrll   altgr   keycode  82 = U+25a1           # □ [U+25A1] WHITE SQUARE
+
+                keycode  83 = KP_Comma         # , [U+002C] COMMA
+        shiftl  keycode  83 = period           # . [U+002E] FULL STOP
+        shiftr  keycode  83 = period           # . [U+002E] FULL STOP
+        altgr   keycode  83 = comma            # , [U+002C] COMMA
+        ctrll   keycode  83 = Remove           #
+shiftl  ctrll   keycode  83 = Remove           #
+shiftr  ctrll   keycode  83 = Remove           #
+shiftl  altgr   keycode  83 = U+2032           # ′ [U+2032] PRIME
+shiftr  altgr   keycode  83 = U+2032           # ′ [U+2032] PRIME
+ctrll   altgr   keycode  83 = U+2033           # ″ [U+2033] DOUBLE PRIME
+
+                keycode  96 = KP_Enter         #


### PR DESCRIPTION
This adds neo.map for the neo keyboard layout (from svn.neo-layout.org )

Please let me know in case of any problems.

For reference, I sent a mail to the mailinglist a while ago: https://lists.altlinux.org/pipermail/kbd/2017-June/000623.html