### PR TITLE
Add dvorak-ukp.map

### DIFF
--- a/data/keymaps/i386/dvorak/dvorak-ukp.map
+++ b/data/keymaps/i386/dvorak/dvorak-ukp.map
@@ -1,0 +1,80 @@
+# dvorak-ukp.map
+# Adapted for UK punctuation by Ben Blain <ben@servc.eu>
+# Originally created by Joe MacMahon <joe@losingthegame.net>
+
+keymaps 0-2,4-6,8-9,12
+alt_is_meta
+include "linux-with-alt-and-altgr.inc"
+strings as usual
+
+keycode   1 = Escape           
+keycode   2 = one              exclam          
+keycode   3 = two              quotedbl         at              nul
+keycode   4 = three            sterling
+	control keycode   4 = Escape          
+keycode   5 = four             dollar           dollar          Control_backslash
+keycode   6 = five             percent         
+	control keycode   6 = Control_bracketright
+keycode   7 = six              asciicircum     
+	control keycode   7 = Control_asciicircum
+keycode   8 = seven            ampersand        braceleft       Control_underscore
+keycode   9 = eight            asterisk         bracketleft     Delete
+keycode  10 = nine             parenleft        bracketright    
+keycode  11 = zero             parenright       braceright      
+keycode  12 = minus           underscore       backslash     Control_underscore
+keycode  13 = equal            plus            
+keycode  14 = Delete           
+	control	keycode  14 = Control_underscore
+keycode  15 = Tab              
+	shift	keycode  15 = Meta_Tab
+keycode  16 = slash            question        
+	control keycode  16 = Delete          
+keycode  17 = comma            less            
+keycode  18 = period           greater         
+keycode  19 = p               
+keycode  20 = y               
+keycode  21 = f               
+keycode  22 = g               
+keycode  23 = c               
+keycode  24 = r               
+keycode  25 = l               
+keycode  26 = bracketleft      braceleft       
+	control keycode  26 = Escape          
+keycode  27 = bracketright     braceright       asciitilde      Control_bracketright
+keycode  28 = Return          
+        alt     keycode  28 = Meta_Control_m
+keycode  29 = Control         
+keycode  30 = a               
+keycode  31 = o               
+keycode  32 = e               
+keycode  33 = u               
+keycode  34 = i               
+keycode  35 = d               
+keycode  36 = h               
+keycode  37 = t               
+keycode  38 = n               
+keycode  39 = s               
+keycode  40 = apostrophe       at
+	control keycode  40 = Control_g       
+		shift	control	keycode  40 = nul
+keycode  41 = grave           notsign      
+keycode  42 = Shift           
+keycode  43 = numbersign      asciitilde
+	control keycode  43 = Control_backslash
+keycode  44 = semicolon       colon           
+keycode  45 = q               
+keycode  46 = j               
+keycode  47 = k               
+keycode  48 = x               
+keycode  49 = b               
+keycode  50 = m               
+keycode  51 = w               
+keycode  52 = v               
+keycode  53 = z               
+keycode  54 = Shift           
+keycode  56 = Alt             
+keycode  57 = space            
+	control keycode  57 = nul             
+keycode  58 = Caps_Lock       
+keycode  86 = backslash        bar              bar              Control_backslash
+keycode  97 = Control         


### PR DESCRIPTION
This adds dvorak-ukp.map, a variant of the dvorak keymap with UK (ISO/IEC 9995-1) punctuation.

For more information see https://servc.eu/content/dvorak-uk-punctuation

I can send the patch to the mailing list if you'd prefer.