### PR TITLE
Add mac-no-latin1.map

### DIFF
--- a/data/keymaps/mac/all/mac-no-latin1.map
+++ b/data/keymaps/mac/all/mac-no-latin1.map
@@ -1,0 +1,194 @@
+# /usr/lib/kbd/keymaps/mac/all/mac-no-latin1.map
+# This is a remake of  Kjetil T. Homme`s no-latin1.map
+# to better suit the Norwegian MacBookPro keyboard layout
+#
+#include "linux-with-alt-and-altgr"
+#include "linux-with-modeshift-altgr"
+	plain keycode  83 = KP_Comma
+	plain keycode 111 = Delete		# "Remove" originally, weird...
+strings as usual
+
+	keycode   1 = Escape
+    alt	keycode   1 = Meta_Escape
+
+	keycode   2 = one	exclam		exclamdown	onesuperior
+    alt	keycode   2 = Meta_one
+
+	keycode   3 = two	quotedbl	apostrophe		twosuperior
+control	keycode   3 = nul
+    alt	keycode   3 = Meta_two
+
+	keycode   4 = three	numbersign	sterling	threesuperior
+control	keycode   4 = Escape
+    alt	keycode   4 = Meta_three
+
+	keycode   5 = four	dollar		currency	onequarter
+control	keycode   5 = Control_backslash
+    alt	keycode   5 = Meta_four
+
+	keycode   6 = five	percent		onehalf		onehalf
+control	keycode   6 = Control_bracketright
+    alt	keycode   6 = Meta_five
+
+	keycode   7 = six	ampersand	threequarters	threequarters
+control	keycode   7 = Control_asciicircum
+    alt	keycode   7 = Meta_six
+
+	keycode   8 = seven	slash		backslash
+control	keycode   8 = Control_underscore
+    alt	keycode   8 = Meta_seven
+
+	keycode   9 = eight	parenleft	bracketleft	braceleft
+control	keycode   9 = Delete
+    alt	keycode   9 = Meta_eight
+
+	keycode  10 = nine	parenright	bracketright	braceright
+    alt	keycode  10 = Meta_nine
+
+	keycode  11 = zero	equal		
+    alt	keycode  11 = Meta_zero
+
+	keycode  12 = plus	question	plusminus	questiondown
+    alt	keycode  12 = Meta_plus
+
+	keycode  13 = apostrophe		dead_acute	dead_grave
+control	keycode  13 = Control_backslash
+    alt	keycode  13 = Meta_backslash
+
+	keycode  14 = Delete
+control	keycode  14 = Control_underscore	# For Emacs' UNDO :-)
+    alt	keycode  14 = Meta_Delete
+
+	keycode  15 = Tab
+    alt	keycode  15 = Meta_Tab
+
+	keycode  16 = +q
+	keycode  17 = +w
+
+	keycode  18 = +e	+E		+eacute		+Eacute
+control	keycode  18 = Control_e
+    alt	keycode  18 = Meta_e
+
+	keycode  19 = +r	+R		registered
+control	keycode  19 = Control_r
+    alt	keycode  19 = Meta_r
+
+	keycode  20 = +t	+T		+thorn		+THORN
+control	keycode  20 = Control_t
+    alt	keycode  20 = Meta_t
+
+	keycode  21 = +y	+Y		ydiaeresis	yen
+control	keycode  21 = Control_y
+    alt	keycode  21 = Meta_y
+
+	keycode  22 = +u	+U		+udiaeresis	+Udiaeresis
+control	keycode  22 = Control_u
+    alt	keycode  22 = Meta_u
+
+	keycode  23 = +i	+I		+idiaeresis	+Idiaeresis
+control	keycode  23 = Tab
+    alt	keycode  23 = Meta_i
+
+	keycode  24 = +o	+O		+ograve		+Ograve
+control	keycode  24 = Control_o
+    alt	keycode  24 = Meta_o
+
+	keycode  25 = +p	+P		paragraph
+control	keycode  25 = Control_p
+    alt	keycode  25 = Meta_p
+
+	keycode  26 = +aring	+Aring		braceright	bracketright
+control	keycode  26 = Control_bracketright
+    alt	keycode  26 = Meta_bracketright
+
+	keycode  27 = asciitilde asciicircum	dead_diaeresis	dead_tilde
+control	keycode  27 = Control_asciicircum
+    alt	keycode  27 = Meta_asciicircum
+
+	keycode  28 = Return
+    alt	keycode  28 = Meta_Control_m
+
+	keycode  29 = Control
+
+	keycode  30 = +a	+A		+aacute		+Aacute
+control	keycode  30 = Control_a
+    alt	keycode  30 = Meta_a
+
+	keycode  31 = +s	+S		ssharp
+control	keycode  31 = Control_s
+
+	keycode  32 = +d	+D		+eth		+ETH
+control	keycode  32 = Control_d
+    alt	keycode  32 = Meta_d
+
+	keycode  33 = +f	+F		ordfeminine	ordfeminine
+control	keycode  33 = Control_f
+    alt	keycode  33 = Meta_f
+
+	keycode  34 = +g
+	keycode  35 = +h
+	keycode  36 = +j
+	keycode  37 = +k
+	keycode  38 = +l
+
+	keycode  39 = +oslash	+Ooblique	bar	backslash
+control	keycode  39 = Control_backslash
+    alt	keycode  39 = Meta_backslash
+
+	keycode  40 = +ae	+AE		braceleft	bracketleft
+control	keycode  40 = Escape
+    alt	keycode  40 = Meta_bracketleft
+
+	keycode  41 = bar	section		brokenbar	paragraph
+control	keycode  41 = Control_backslash
+    alt	keycode  41 = Meta_bar
+
+	keycode  42 = Shift
+
+	keycode  43 = at	 asterisk	dead_circumflex	multiply
+    alt	keycode  43 = Meta_apostrophe
+
+	keycode  44 = +z
+
+	keycode  45 = +x	+X		multiply
+control	keycode  45 = Control_x
+    alt	keycode  45 = Meta_x
+
+	keycode  46 = +c	+C		ccedilla	copyright
+control	keycode  46 = Control_c
+    alt	keycode  46 = Meta_c
+
+	keycode  47 = +v
+	keycode  48 = +b
+
+	keycode  49 = +n	+N		+ntilde		+Ntilde
+control	keycode  49 = Control_n
+    alt	keycode  49 = Meta_n
+
+	keycode  50 = +m	+M		mu		masculine
+control	keycode  50 = Control_m
+    alt	keycode  50 = Meta_m
+
+	keycode  51 = comma	semicolon	cedilla		guillemotleft
+    alt	keycode  51 = Meta_comma
+
+	keycode  52 = period	colon		periodcentered	guillemotright
+    alt	keycode  52 = Meta_period
+
+	keycode  53 = minus	underscore	hyphen
+control	keycode  53 = Control_underscore
+    alt	keycode  53 = Meta_minus
+
+	keycode  54 = Shift
+	keycode  56 = AltR
+
+	keycode  57 = space	space		nobreakspace	nobreakspace
+control	keycode  57 = nul
+    alt	keycode  57 = Meta_space
+
+	keycode  58 = Caps_Lock
+
+	keycode  86 = less	greater		guillemotleft	guillemotright
+    alt	keycode  86 = Meta_less
+
+	keycode  97 = Control


### PR DESCRIPTION
This is a keyboard map for the Norwegian Macbook pro.
Sorry for the previously compressed file, I deleted it and will try again.