### PR TITLE
Fix infinite loop of vlock if locked VC is closed

### DIFF
--- a/src/vlock/auth.c
+++ b/src/vlock/auth.c
@@ -140,9 +140,9 @@ int get_password(pam_handle_t *pamh, const char *username, const char *tty)
 				fflush(stdout);
 				/*
 				 * EOF encountered on read?
-				 * If not on VT, check stdin.
+				 * Check stdin.
 				 */
-				if (is_vt || isatty(STDIN_FILENO)) {
+				if (isatty(STDIN_FILENO)) {
 					/* Ignore error. */
 					sleep(SHORT_DELAY);
 					break;


### PR DESCRIPTION
vlock enters infinite loop if text console is closed abruptly (for example with 'systemctl stop getty@ttyX.service', where X is the number of tty locked previously by vlock). On the text console, the check whether STDIN_FILENO still refers to a teminal has no effect, because the first part of the condition is true (on virtual terminal it's fine... but who really wants to lock virtual terminal with vlock, right?:))