### PR TITLE
setmetamode: use unsigned int type for KDGKBMETA / KDSKBMETA

### DIFF
--- a/src/setmetamode.c
+++ b/src/setmetamode.c
@@ -50,7 +50,7 @@ report(int meta)
 
 struct meta {
 	char *name;
-	int val;
+	unsigned int val;
 } metas[] = {
 	{ "metabit", K_METABIT },
 	{ "meta", K_METABIT },
@@ -64,7 +64,7 @@ struct meta {
 
 int main(int argc, char **argv)
 {
-	char ometa, nmeta;
+	unsigned int ometa, nmeta;
 	struct meta *mp;
 
 	set_progname(argv[0]);


### PR DESCRIPTION
alsauser@pragmasoft.com reported that he detected a stack smash
and analyzed the problem as allocating too little space for
the resulting put_user after calling ioctl KDGKBMETA.
The ometa variable should be defined as unsigned int.

While at it and for correctness, also nmeta and thus the
val member of the struct meta where changed to unsigned
int as it seems the kernel wants to take this type
(but should be harmless to use char).

Original bug report at https://bugs.debian.org/872623