### PR TITLE
Update po/*po files and convert all *po files to UTF-8

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-12-30 18:14+01:00\n"
 "Last-Translator: Petr Pisar <petr.pisar@atlas.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -20,45 +20,45 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "použití: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Nebylo možné získat deskriptor souboru odkazující na konzolu"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: neznámý přepínač\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: neplatné číslo VT\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 je konzole a nemůže být dealokován\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "nelze dealokovat konzolu %d: IOCTL VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "verze dumpkeys %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -95,7 +95,7 @@ msgstr ""
 "\t-d --compose-only   zobrazit jen kombinace kláves compose\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -104,7 +104,7 @@ msgstr ""
 "\t\t\t    interpretovat kódy akce znaků, že jsou z\n"
 "\t\t\t    určené znakové sady\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -113,17 +113,17 @@ msgstr ""
 "\t-v --verbose\n"
 "\t-V --version\t    zobrazí číslo verze\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "neznámá znaková sada %s - ignoruji požadavek na znakovou sadu\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: chyba při čtení režimu klávesnice: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -134,7 +134,7 @@ msgstr ""
 "(číselná hodnota, symbol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -157,41 +157,31 @@ msgstr ""
 "\t-V --version         zobrazit verzi programu\n"
 "\t-n --next-available  zobrazit číslo dalšího nealokovaného VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Nemohu číst VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Nebylo možné otevřít %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Nebylo možné získat deskriptor souboru odkazující na konzolu\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "použití: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Jednoduché scankódy xx (hex) versus kódy kláves (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr "0 je chyba; pro 1-88 (0x01-0x58) se scankód rovná kódu klávesy\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "pro 1-%d (0x01-0x%02x) se scankód rovná kódu klávesy\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -202,12 +192,12 @@ msgstr ""
 "\n"
 "Uvozené scankódy e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "získání kódu klávesy pro scankód 0x%x selhalo: IOCTL KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -244,71 +234,71 @@ msgstr "Chyba: Málo argumentů.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Chyba: Nerozpoznaná akce: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "použití: kbd_mode [-a|-u|-k|-s] [-C zařízení]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Klávesnice je v přímém režimu (scankódy)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Klávesnice je v prostředně přímém režimu (kódy kláves)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Klávesnice je v implicitním režimu (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Klávesnice je v režimu Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Klávesnice je v nějakém neznámém režimu\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Rychlost opakování nastavena %.1f z/s (zpoždění = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Použití: kbdrate [-V | --version] [-s] [-r rychlost] [-d zpoždění]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Nemohu otevřít /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "chyba: getfont zavoláno s count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "bug: getfont pomocí GIO_FONT potřebuje buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: nedostatek paměti\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "divné… ct změněno z %d na %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -317,21 +307,36 @@ msgstr ""
 "Vypadá to, že toto jádro je starší než 1.1.92.\n"
 "Žádná tabulka mapování Unicodu nebyla zavedena.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Nebylo možné otevřít %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Nebylo možné získat deskriptor souboru odkazující na konzolu\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s z %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "nedostatek paměti"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "nelze inicializovat pole: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Chyba při zápisu mapy do souboru"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "nemožné: není meta?\n"
@@ -351,71 +356,71 @@ msgstr "KDGKBSENT: %s: Nelze získat řetězec funkční klávesy"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: Nelze získat tabulku diakritik"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "nelze získat mapy kláves %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "odnastavení klávesy %d z tabulky %d selhalo"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key zavolán se špatným kódem klávesy %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "přidání mapy %d rozbije explicitní řádek s mapou kláves"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "navázání klávesy %d na tabulku %d selhalo"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "nemožná chyba v lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "symbol nelze získat podle chybného typu: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "symbol typu %d nelze získat podle chybného indexu: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "předpokládá se iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "předpokládá se iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "předpokládá se iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "předpokládá se iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "předpokládá se iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "neznámý symbol klávesy '%s'\n"
@@ -465,12 +470,12 @@ msgstr "KDSKBENT: %s: mapu kláves nelze dealokovat nebo vyprázdnit"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: nebylo možné vrátit se do původního režimu klávesnice"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "navázání řetězce „%s“ na funkci %s selhalo"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "vyprázdnění řetězce %s selhalo"
@@ -479,7 +484,7 @@ msgstr "vyprázdnění řetězce %s selhalo"
 msgid "too many compose definitions"
 msgstr "příliš mnoho definic skladby"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -497,7 +502,7 @@ msgstr[2] ""
 "\n"
 "Změněno %d klíčů"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -505,7 +510,7 @@ msgstr[0] "Změněn %d řetězec"
 msgstr[1] "Změněny %d řetězce"
 msgstr[2] "Změněno %d řetězců"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
@@ -513,7 +518,7 @@ msgstr[0] "Zavedena %d definice skladby"
 msgstr[1] "Zavedeny %d definice skladby"
 msgstr[2] "Zavedeno %d definic skladby"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Žádná změna v definicích skladby)"
 
@@ -582,7 +587,7 @@ msgstr ""
 "\n"
 "Rozpoznávané názvy modifikátorů a jejich čísla sloupců:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -627,17 +632,12 @@ msgstr ""
 "  -v --verbose       hlásí změny\n"
 "  -V --version       zobrazí číslo verze\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s z %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: Přepínače --unicode a --ascii se vzájemně vylučují\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -646,7 +646,7 @@ msgstr ""
 "%s: pozor: zavádí se neunikódová mapa kláves na unikódové konzoly\n"
 "    (nechtěli jste snad „kbd_mode -a“?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -655,17 +655,17 @@ msgstr ""
 "%s: pozor: zavádí se unikódová mapa kláves na neunikódové konzoly\n"
 "    (nechtěli jste snad „kbd_mode -u“?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "%s nelze nalézt\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "soubor%s nelze otevřít\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -674,27 +674,27 @@ msgstr ""
 "Použití:\n"
 "\t%s [-C konzola] [-o mapa.původní]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Špatný řádek vstupu: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Číslo glyphu (0x%x) větší než délka písma\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Špatný konec rozsahu (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr "%s: Špatný rozsah Unicode odpovídající rozsahu pozic písma 0x%x-0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -703,22 +703,22 @@ msgstr ""
 "%s: Rozsah Unicode U+%x-U+%x není stejné délky jako rozsah pozic písma 0x"
 "%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: smetí na konci (%s) ignorováno\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Načítám mapu unicode ze souboru %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Varování: řádek příliš dlouhý\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -727,85 +727,85 @@ msgstr ""
 "%s: nenačítám prázdnou unimap\n"
 "(pokud na tom trváte: použijte přepínač -f pro vnucení)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "položka"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "položek"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Uložena mapa unicode do `%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Připojena mapa Unicode\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "použití: %s [-V] [-v] [-o mapa.původní] soubor-mapy\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: nemohu otevřít soubor mapy _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Nemohu stat soubor mapy"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Načítám binární mapu obrazovky přímo do písma ze souboru %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Chyba při čtení mapy ze souboru `%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Načítám binární mapu obrazovky unicode ze souboru %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Načítám symbolickou mapu obrazovky ze souboru %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Chyba při zpracovávání symbolické mapy z `%s', řádek %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Chyba při zápisu mapy do souboru\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Nemohu číst mapu konzoly\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Mapa obrazovky uložena v `%s'\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -838,11 +838,11 @@ msgstr ""
 "  -h, --help           vypíše stručný návod na použití.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Vlastníka současného TTY nebylo možné zjistit!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: Nedovolené číslo VT"
@@ -889,96 +889,96 @@ msgstr "Použije se VT %s"
 msgid "Cannot open %s read/write"
 msgstr "%s nelze otevřít pro čtení i zápis"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "VT %d se nepodařilo aktivovat"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Aktivace přerušena?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Nebylo možné dealokovat konzolu %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: krátká tabulka unicode ucs2\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: krátká tabulka unicode utf8\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: špatné utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: neznámá chyba utf8\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: krátká tabulka unicode\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Chyba při čtení vstupního písma"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Špatné volání readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Nepodporovaný režim souboru psf (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Nepodporovaná verze psf (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: nulová délka vstupního písma?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: nulová velikost vstupního znaku?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Vstupní soubor: špatná délka vstupu (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Vstupní soubor: smetí na konci\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: neplatné unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Nemohu zapsat hlavičku souboru písma"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Nemohu zapsat soubor písma"
@@ -1062,38 +1062,48 @@ msgstr "%s: soubor psf s neznámým magickým číslem\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: vstupní písmo nemá index\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: nemohu najít soubor videorežimu %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: nemohu najít soubor videorežimu %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Neplatný počet řádků\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Starý režim: %d×%d  New mode: %d×%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Starý počet #scanline: %d  Nový #scanline: %d  Výška znaku: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: příkaz `%s' selhal\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: nezapomeňte změnit TERM (možná na con%dx%d nebo linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1106,41 +1116,41 @@ msgstr ""
 "nebo: resizecons -lines ŘÁDKŮ, ke ŘÁDKŮ je jedno z 25, 28, 30, 34, 36, 40, "
 "44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: nemohu získat oprávnění k I/O.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "použití: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Chyba při čtení %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "nemohu načíst %s a nemohu ioctl dump\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "nemohu načíst %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Divné ... obrazovka je zároveň %d×%d a %d×%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Chyba při zápisu zachycení obrazovky\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1195,12 +1205,12 @@ msgstr ""
 "    -V\t\tVytisknout verzi a skončit.\n"
 "Soubory jsou načítány z aktuálního adresáře nebo %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: příliš mnoho vstupních souborů\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1209,122 +1219,122 @@ msgstr ""
 "setfont: nemohu zároveň obnovovat z ROM znaků a ze souboru. Písmo "
 "nezměněno.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Špatná výška znaku %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Špatná šířka znaku %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: pozice písma 32 je neprázdná\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: vymazal jsem ji\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: pozadí bude vypadat divně\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Načítám  %d-znakové písmo %d×%d ze souboru %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Načítám %d-znakové písmo %d×%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Načítám %d-znakové písmo %d×%d (%d) ze souboru %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Načítám %d-znakové písmo %d×%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: chyba v do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Načítám mapovací tabulku Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Nemohu otevřít soubor písma %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr "Při načítání více písem musí všechna být písma psf - %s není\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Načten %d-znakové písmo %d×%d ze souboru %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Při načítání více písem musí všechna míst stejnou výšku\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "Při načítání více písem musí všechna míst stejnou šířku\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Nemohu najít implicitní písmo\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Nemohu najít písmo %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Čtu soubor písma %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Chybí koncový konec řádku v souboru combine\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Příliš mnoho souborů pro kombinování\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - písmo z restorefont? Používám první polovinu.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Špatná velikost vstupního souboru\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1333,22 +1343,22 @@ msgstr ""
 "Tento soubor obsahuje tři písma: 8×8, 8×14 a 8×16. Naznačte prosím\n"
 "pomocí přepínače -8 nebo -14 nebo -16, které chcete načíst.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr "Požádali jste o velikost písma %d, ale tady je možné jen 8, 14, 16.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Nenalezeno nic k uložení\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Uložen %d-znakový soubor písma %d×%d do %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1359,19 +1369,19 @@ msgstr ""
 " (kde scankód je buď xx nebo e0xx, dáno šestnáctkově,\n"
 "  a kód klávesy je dán desítkově)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "očekáván sudý počet argumentů"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "chyba při čtení scankódu"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "kód mimo hranice"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "nastavení scankódu %x na kód klávesy %d selhalo: IOCTL KDSETKEYCODE"
@@ -1547,12 +1557,12 @@ msgstr "starý stav:   "
 msgid "new state:    "
 msgstr "nový stav:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "použití: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1587,39 +1597,39 @@ msgstr ""
 "   -V     zobrazí číslo verze\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Chyba: %s: Neplatná hodnota v položce %u na řádku %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Chyba: %s: Nedostatečný počet položek na řádku %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Chyba: %s: Řádek %u neočekávaně skončil.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Chyba: %s: Řádek %u je příliš dlouhý.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "nemohu obnovit původní tabulku překladu\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "nemohu obnovit původní unimap\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "nemohu změnit tabulku překladu\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1668,16 +1678,16 @@ msgstr ""
 "Zobrazuje se %d-znakový font\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?NEZNÁMÝ?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "režim klávesnice byl %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1686,12 +1696,12 @@ msgstr ""
 "[ pokud to zkoušíte pod X, možná to nebude fungovat,\n"
 "protože X server také čte /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "chytil jsem signál %d, uklízím...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1749,11 +1759,11 @@ msgstr "stisknutí"
 msgid "keycode %3d %s\n"
 msgstr "kód klávesy %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "použití: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1763,17 +1773,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Celý displej konzole je nyní zcela uzamknut uživatelem %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "%s je nyní uzamknut uživatelem %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr "Použijte Alt a funkční klávesy pro přepnutí na jiné virtuální konzoly."
 
@@ -1782,7 +1792,7 @@ msgstr "Použijte Alt a funkční klávesy pro přepnutí na jiné virtuální k
 msgid "Try `%s --help' for more information.\n"
 msgstr "Podrobnosti získáte příkazem „%s --help“.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1810,16 +1820,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "nerozpoznaný uživatel"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "standardní vstup není TTY"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Tento TTY (%s) není virtuální konzola.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Nelze uzamknout celý displej konzole.\n"

--- a/po/da.po
+++ b/po/da.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: KBabel 1.11.4\n"
@@ -32,7 +32,7 @@ msgstr "brug: chvt N\n"
 #: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
 #: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
-msgstr "Kunne ikke få en filidentifikator der refererer til konsollen"
+msgstr "Kunne ikke fÃ¥ en filidentifikator der refererer til konsollen"
 
 #: src/deallocvt.c:36
 #, c-format
@@ -84,15 +84,15 @@ msgstr ""
 "\n"
 "gyldige flag er:\n"
 "\n"
-"\t-h --help\t    vis denne hjælpetekst\n"
+"\t-h --help\t    vis denne hjÃ¦lpetekst\n"
 "\t-i --short-info\t    vis information om tastaturdrivrutine\n"
-"\t-l --long-info\t    vis ovenstående og symboler kendte for loadkeys\n"
+"\t-l --long-info\t    vis ovenstÃ¥ende og symboler kendte for loadkeys\n"
 "\t-n --numeric\t    vis tastetabel i heksadecimal notation\n"
 "\t-f --full-table\t    brug ikke kort notation, en linje per tastekode\n"
-"\t-1 --separate-lines en linje per (ændrer,tastekode)-par\n"
+"\t-1 --separate-lines en linje per (Ã¦ndrer,tastekode)-par\n"
 "\t   --funcs-only\t    vis kun strenge for funktionstaster\n"
 "\t   --keys-only\t    vis kun tastebindinger\n"
-"\t   --compose­only   vis kun \"compose\"-tastekombinationer\n"
+"\t   --composeÂ­only   vis kun \"compose\"-tastekombinationer\n"
 "\t-c --charset="
 
 #: src/dumpkeys.c:48
@@ -102,7 +102,7 @@ msgid ""
 "\t\t\t    specified character set\n"
 msgstr ""
 "\t\t\t    tolk tegnhandlingskoder som om de er fra det\n"
-"\t\t\t    angivne tegnsæt\n"
+"\t\t\t    angivne tegnsÃ¦t\n"
 
 #: src/dumpkeys.c:52
 #, c-format
@@ -114,12 +114,12 @@ msgstr ""
 #: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
-msgstr "ukendt tegnsæt %s - ignorerer anmodning om tegnsæt\n"
+msgstr "ukendt tegnsÃ¦t %s - ignorerer anmodning om tegnsÃ¦t\n"
 
 #: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
-msgstr "%s: fejl ved læsning af tastaturstilstand\n"
+msgstr "%s: fejl ved lÃ¦sning af tastaturstilstand\n"
 
 #: src/dumpkeys.c:177
 #, c-format
@@ -129,7 +129,7 @@ msgid ""
 "\n"
 msgstr ""
 "Symboler som genkendes af %s:\n"
-"(numerisk værdi, symbol)\n"
+"(numerisk vÃ¦rdi, symbol)\n"
 "\n"
 
 #: src/fgconsole.c:20
@@ -151,13 +151,13 @@ msgstr ""
 "\n"
 "Gyldige tilvalg er:\n"
 "\n"
-"\t-h --help            vis denne hjælpetekst\n"
+"\t-h --help            vis denne hjÃ¦lpetekst\n"
 "\t-V --version         vis versionsnummer\n"
-"\t-n --next-available  vis nummer på næste utildelte VT\n"
+"\t-n --next-available  vis nummer pÃ¥ nÃ¦ste utildelte VT\n"
 
 #: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
-msgstr "Kunne ikke læse VTNO: "
+msgstr "Kunne ikke lÃ¦se VTNO: "
 
 #: src/getkeycodes.c:21
 #, c-format
@@ -167,18 +167,18 @@ msgstr "brug: getkeycodes\n"
 #: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
-msgstr "Enkle aflæsningskoder xx (hex) mod tastekoder (dec)\n"
+msgstr "Enkle aflÃ¦sningskoder xx (hex) mod tastekoder (dec)\n"
 
 #: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
-"0 er en fejl, for 1-88 (0x01-0x58) er aflæsningskoden lig med tastekoden\n"
+"0 er en fejl, for 1-88 (0x01-0x58) er aflÃ¦sningskoden lig med tastekoden\n"
 
 #: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
-msgstr "for 1-%d (0x01-0x%02x) er aflæsningskoden lig med tastekoden\n"
+msgstr "for 1-%d (0x01-0x%02x) er aflÃ¦sningskoden lig med tastekoden\n"
 
 #: src/getkeycodes.c:71
 #, c-format
@@ -189,12 +189,12 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Udvidede aflæsningskoder e0 xx (hex)\n"
+"Udvidede aflÃ¦sningskoder e0 xx (hex)\n"
 
 #: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
-msgstr "mislykkedes med at hente tastekoden for aflæsningskode 0x%x\n"
+msgstr "mislykkedes med at hente tastekoden for aflÃ¦sningskode 0x%x\n"
 
 #: src/getunimap.c:32
 #, c-format
@@ -238,12 +238,12 @@ msgstr "brug: kbd_mode [-a|-u|-k|-s] [-C enhed]\n"
 #: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
-msgstr "Tastaturet er i rå (aflæsningskode-)tilstand\n"
+msgstr "Tastaturet er i rÃ¥ (aflÃ¦sningskode-)tilstand\n"
 
 #: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
-msgstr "Tastaturet er i halvrå (tastekode-)tilstand\n"
+msgstr "Tastaturet er i halvrÃ¥ (tastekode-)tilstand\n"
 
 #: src/kbd_mode.c:93
 #, c-format
@@ -272,7 +272,7 @@ msgstr "Brug: kbdrate [-V] [-s] [-r frekvens] [-d forsinkelse]\n"
 
 #: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
-msgstr "Kan ikke åbne /dev/port"
+msgstr "Kan ikke Ã¥bne /dev/port"
 
 #: src/kdfontop.c:98
 #, c-format
@@ -282,7 +282,7 @@ msgstr "fejl: getfont kaldt med count<256\n"
 #: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
-msgstr "fejl: getfont med GIO_FONT behøver buf.\n"
+msgstr "fejl: getfont med GIO_FONT behÃ¸ver buf.\n"
 
 #: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
@@ -292,7 +292,7 @@ msgstr "%s: hukommelsen slut\n"
 #: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
-msgstr "mærkeligt... ct ændredes fra %d til %d\n"
+msgstr "mÃ¦rkeligt... ct Ã¦ndredes fra %d til %d\n"
 
 #: src/kdmapop.c:188
 #, c-format
@@ -300,18 +300,18 @@ msgid ""
 "It seems this kernel is older than 1.1.92\n"
 "No Unicode mapping table loaded.\n"
 msgstr ""
-"Det ser ud til at denne kerne er ældre end 1.1.92\n"
-"Ingen UCS-tabel indlæst.\n"
+"Det ser ud til at denne kerne er Ã¦ldre end 1.1.92\n"
+"Ingen UCS-tabel indlÃ¦st.\n"
 
 #: src/libcommon/getfd.c:69
 #, c-format
 msgid "Couldn't open %s\n"
-msgstr "Kunne ikke åbne %s\n"
+msgstr "Kunne ikke Ã¥bne %s\n"
 
 #: src/libcommon/getfd.c:86
 #, c-format
 msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Kunne ikke få en filidentifikator der referere til konsollen\n"
+msgstr "Kunne ikke fÃ¥ en filidentifikator der referere til konsollen\n"
 
 #: src/libcommon/version.c:29
 #, c-format
@@ -357,27 +357,27 @@ msgstr ""
 #: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, fuzzy, c-format
 msgid "unable to get keymap %d"
-msgstr "deallokér keymap %d\n"
+msgstr "deallokÃ©r keymap %d\n"
 
 #: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
-msgstr "kunne ikke binde tast %d til værdien %d\n"
+msgstr "kunne ikke binde tast %d til vÃ¦rdien %d\n"
 
 #: src/libkeymap/kmap.c:125
 #, fuzzy, c-format
 msgid "lk_add_key called with bad keycode %d"
-msgstr "addkey kaldt med dårlig keycode %d"
+msgstr "addkey kaldt med dÃ¥rlig keycode %d"
 
 #: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
-msgstr "tilføjelse af tabel %d strider mod eksplicit keymaps-linje"
+msgstr "tilfÃ¸jelse af tabel %d strider mod eksplicit keymaps-linje"
 
 #: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
-msgstr "kunne ikke binde tast %d til værdien %d\n"
+msgstr "kunne ikke binde tast %d til vÃ¦rdien %d\n"
 
 #: src/libkeymap/kmap.c:239
 #, fuzzy
@@ -432,7 +432,7 @@ msgstr "%s: kunne ikke skifte til UCS-tilstand\n"
 #: src/libkeymap/loadkeys.c:50
 #, fuzzy, c-format
 msgid "Keymap %d: Permission denied"
-msgstr "Keymap %d: Tilladelse nægtet\n"
+msgstr "Keymap %d: Tilladelse nÃ¦gtet\n"
 
 #: src/libkeymap/loadkeys.c:58
 #, fuzzy, c-format
@@ -446,12 +446,12 @@ msgstr "    MISLYKKEDES"
 #: src/libkeymap/loadkeys.c:62
 #, fuzzy, c-format
 msgid "failed to bind key %d to value %d"
-msgstr "kunne ikke binde tast %d til værdien %d\n"
+msgstr "kunne ikke binde tast %d til vÃ¦rdien %d\n"
 
 #: src/libkeymap/loadkeys.c:72
 #, fuzzy, c-format
 msgid "deallocate keymap %d"
-msgstr "deallokér keymap %d\n"
+msgstr "deallokÃ©r keymap %d\n"
 
 #: src/libkeymap/loadkeys.c:76
 #, fuzzy, c-format
@@ -466,7 +466,7 @@ msgstr "%s: kan ikke deallokere eller nulstille keymap\n"
 #: src/libkeymap/loadkeys.c:101
 #, fuzzy, c-format
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
-msgstr "%s: kunne ikke gå tilbage til oprindelig tastatyrtilstand\n"
+msgstr "%s: kunne ikke gÃ¥ tilbage til oprindelig tastatyrtilstand\n"
 
 #: src/libkeymap/loadkeys.c:164
 #, fuzzy, c-format
@@ -500,10 +500,10 @@ msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] ""
 "\n"
-"Ændrede %d %s og %d %s.\n"
+"Ã†ndrede %d %s og %d %s.\n"
 msgstr[1] ""
 "\n"
-"Ændrede %d %s og %d %s.\n"
+"Ã†ndrede %d %s og %d %s.\n"
 
 #: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
@@ -515,17 +515,17 @@ msgstr[1] "for mange kompositionsdefinitioner\n"
 #: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
-msgstr "(Ingen ændringer i kompositionsdefinitioner)\n"
+msgstr "(Ingen Ã¦ndringer i kompositionsdefinitioner)\n"
 
 #: src/libkeymap/summary.c:95
 #, c-format
 msgid "keycode range supported by kernel:           1 - %d\n"
-msgstr "tastekodeinterval som understøttes af kernen:        1 - %d\n"
+msgstr "tastekodeinterval som understÃ¸ttes af kernen:        1 - %d\n"
 
 #: src/libkeymap/summary.c:97
 #, c-format
 msgid "max number of actions bindable to a key:         %d\n"
-msgstr "største antal handlinger bindelige til en tast:   %d\n"
+msgstr "stÃ¸rste antal handlinger bindelige til en tast:   %d\n"
 
 #: src/libkeymap/summary.c:99
 #, fuzzy, c-format
@@ -540,17 +540,17 @@ msgstr "hvoraf %d er dynamisk allokerede\n"
 #: src/libkeymap/summary.c:105
 #, c-format
 msgid "ranges of action codes supported by kernel:\n"
-msgstr "interval af handlingskoder som understøttes af kernen:\n"
+msgstr "interval af handlingskoder som understÃ¸ttes af kernen:\n"
 
 #: src/libkeymap/summary.c:111
 #, c-format
 msgid "number of function keys supported by kernel: %d\n"
-msgstr "antal funktionstaster som understøttes af kernen: %d\n"
+msgstr "antal funktionstaster som understÃ¸ttes af kernen: %d\n"
 
 #: src/libkeymap/summary.c:113
 #, c-format
 msgid "max nr of compose definitions: %d\n"
-msgstr "største antal kompositionsdefinitioner: %d\n"
+msgstr "stÃ¸rste antal kompositionsdefinitioner: %d\n"
 
 #: src/libkeymap/summary.c:115
 #, fuzzy, c-format
@@ -565,7 +565,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Følgende synonymer genkendes:\n"
+"FÃ¸lgende synonymer genkendes:\n"
 "\n"
 
 #: src/libkeymap/summary.c:142
@@ -580,7 +580,7 @@ msgid ""
 "Recognized modifier names and their column numbers:\n"
 msgstr ""
 "\n"
-"Genkendte ændrernavn og deres kolonnenummer:\n"
+"Genkendte Ã¦ndrernavn og deres kolonnenummer:\n"
 
 #: src/loadkeys.c:32
 #, fuzzy, c-format
@@ -613,17 +613,17 @@ msgstr ""
 "Gyldige tilvalg er:\n"
 "\n"
 "  -a --ascii         gennemtving konvertering til ASCII\n"
-"  -b --bkeymap       udskriv en binær keymap til standardud\n"
+"  -b --bkeymap       udskriv en binÃ¦r keymap til standardud\n"
 "  -c --clearcompose  nulstil kernens kompositionstabel\n"
 "  -C <cons1,cons2,...> --console=<cons1,cons2,...>\n"
 "                     konsolenhederne der skal bruges\n"
-"  -d --default       indlæs \"%s\"\n"
-"  -h --help          vis denne hjælpetekst\n"
+"  -d --default       indlÃ¦s \"%s\"\n"
+"  -h --help          vis denne hjÃ¦lpetekst\n"
 "  -m --mktable       udskriv en \"defkeymap.c\" til standardud\n"
 "  -q --quiet         undertryk alt normal udskrift\n"
-"  -s --clearstrings  nulstíl kernens strengtabel\n"
+"  -s --clearstrings  nulstÃ­l kernens strengtabel\n"
 "  -u --unicode       gennemtving konvertering til UCS\n"
-"  -v --verbose       udskriv ændringerne\n"
+"  -v --verbose       udskriv Ã¦ndringerne\n"
 
 #: src/loadkeys.c:166
 #, c-format
@@ -636,8 +636,8 @@ msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
 "    (perhaps you want to do `kbd_mode -a'?)\n"
 msgstr ""
-"%s: advarsel: indlæser ikke-UCS keymap på UCS konsol\n"
-"    (måske vil du gerne lave 'kbd_mode -a'?)\n"
+"%s: advarsel: indlÃ¦ser ikke-UCS keymap pÃ¥ UCS konsol\n"
+"    (mÃ¥ske vil du gerne lave 'kbd_mode -a'?)\n"
 
 #: src/loadkeys.c:199
 #, c-format
@@ -645,8 +645,8 @@ msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
 "    (perhaps you want to do `kbd_mode -u'?)\n"
 msgstr ""
-"%s: advarsel: indlæser UCS keymap på ikke-UCS konsol\n"
-"    (måske vil du gerne lave 'kbd_mode -u'?)\n"
+"%s: advarsel: indlÃ¦ser UCS keymap pÃ¥ ikke-UCS konsol\n"
+"    (mÃ¥ske vil du gerne lave 'kbd_mode -u'?)\n"
 
 #: src/loadkeys.c:217
 #, c-format
@@ -656,7 +656,7 @@ msgstr "Kan ikke finde %s\n"
 #: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
-msgstr "Kan ikke åbne fil %s\n"
+msgstr "Kan ikke Ã¥bne fil %s\n"
 
 #: src/loadunimap.c:45
 #, c-format
@@ -675,12 +675,12 @@ msgstr "Fejlagtig inddatalinje: %s\n"
 #: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
-msgstr "%s: Tegnnummer (0x%x) større end skrifttypelængde\n"
+msgstr "%s: Tegnnummer (0x%x) stÃ¸rre end skrifttypelÃ¦ngde\n"
 
 #: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
-msgstr "%s: Fejlagtigt slut på interval (0x%x)\n"
+msgstr "%s: Fejlagtigt slut pÃ¥ interval (0x%x)\n"
 
 #: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
@@ -695,18 +695,18 @@ msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
 "%x-0x%x\n"
 msgstr ""
-"%s: UCS-interval U+%x-U+%x er ikke af samme længde som "
+"%s: UCS-interval U+%x-U+%x er ikke af samme lÃ¦ngde som "
 "skrifttypespositionsinterval 0x%x-0x%x\n"
 
 #: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
-msgstr "%s: efterfølgende snavs (%s) ignoreret\n"
+msgstr "%s: efterfÃ¸lgende snavs (%s) ignoreret\n"
 
 #: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
-msgstr "Indlæser UCS-tabel fra fil %s\n"
+msgstr "IndlÃ¦ser UCS-tabel fra fil %s\n"
 
 #: src/loadunimap.c:292
 #, c-format
@@ -719,8 +719,8 @@ msgid ""
 "%s: not loading empty unimap\n"
 "(if you insist: use option -f to override)\n"
 msgstr ""
-"%s: indlæser ikke tom ucs-tabel\n"
-"(hvis du insisterer: brug flaget -f til at tilsidesætte)\n"
+"%s: indlÃ¦ser ikke tom ucs-tabel\n"
+"(hvis du insisterer: brug flaget -f til at tilsidesÃ¦tte)\n"
 
 #: src/loadunimap.c:323
 msgid "entry"
@@ -738,7 +738,7 @@ msgstr "Gemte ucs-tabel til \"%s\"\n"
 #: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
-msgstr "Tilføjede UCS-tabel\n"
+msgstr "TilfÃ¸jede UCS-tabel\n"
 
 #: src/mapscrn.c:69
 #, fuzzy, c-format
@@ -748,32 +748,32 @@ msgstr "brug: %s [-v] [-o originaltabel] tabelfil\n"
 #: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
-msgstr "mapscrn: kan ikke åbne tabelfil _%s_\n"
+msgstr "mapscrn: kan ikke Ã¥bne tabelfil _%s_\n"
 
 #: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
-msgstr "Kan ikke tage status på tabelfil"
+msgstr "Kan ikke tage status pÃ¥ tabelfil"
 
 #: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
-msgstr "Indlæser binær direkte-til-skrifttype-skærmtabel fra fil %s\n"
+msgstr "IndlÃ¦ser binÃ¦r direkte-til-skrifttype-skÃ¦rmtabel fra fil %s\n"
 
 #: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
-msgstr "Fejl ved læsning af tabel fra fil \"%s\"\n"
+msgstr "Fejl ved lÃ¦sning af tabel fra fil \"%s\"\n"
 
 #: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
-msgstr "Indlæser binær UCS-skærmfil fra fil %s\n"
+msgstr "IndlÃ¦ser binÃ¦r UCS-skÃ¦rmfil fra fil %s\n"
 
 #: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
-msgstr "Indlæser symbolsk skærmtabel fra fil %s\n"
+msgstr "IndlÃ¦ser symbolsk skÃ¦rmtabel fra fil %s\n"
 
 #: src/mapscrn.c:181
 #, c-format
@@ -788,12 +788,12 @@ msgstr "Fejl ved skrivning af tabel til fil\n"
 #: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
-msgstr "Kan ikke læse konsoltabel\n"
+msgstr "Kan ikke lÃ¦se konsoltabel\n"
 
 #: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
-msgstr "Gemte skærmtabel i \"%s\"\n"
+msgstr "Gemte skÃ¦rmtabel i \"%s\"\n"
 
 #: src/openvt.c:48
 #, fuzzy, c-format
@@ -817,19 +817,19 @@ msgid ""
 msgstr ""
 "Brug: %s [TILVALG] -- kommando\n"
 "\n"
-"Dette program hjælper dig med at starte et program på en ny virtuel terminal "
+"Dette program hjÃ¦lper dig med at starte et program pÃ¥ en ny virtuel terminal "
 "(VT).\n"
 "\n"
 "Tilvalg:\n"
 "  -c, --console=NUM   brug det angivne VT-nummer;\n"
-"  -f, --force         gennemtving åbning af en VT uden at tjekke;\n"
-"  -l, --login         gør kommandoen til en login-skál;\n"
-"  -u, --user          find ejeren på den aktuelle VT;\n"
+"  -f, --force         gennemtving Ã¥bning af en VT uden at tjekke;\n"
+"  -l, --login         gÃ¸r kommandoen til en login-skÃ¡l;\n"
+"  -u, --user          find ejeren pÃ¥ den aktuelle VT;\n"
 "  -s, --switch        skift til den nye VT;\n"
-"  -w, --wait          vent på at kommandoen bliver færdig;\n"
+"  -w, --wait          vent pÃ¥ at kommandoen bliver fÃ¦rdig;\n"
 "  -v, --verbose       udskriv en besked for hver handling;\n"
 "  -V, --version       udskriv programversion og afslut;\n"
-"  -h, --help          udskriv en kort hjælpetekst.\n"
+"  -h, --help          udskriv en kort hjÃ¦lpetekst.\n"
 "\n"
 
 #: src/openvt.c:140
@@ -852,7 +852,7 @@ msgstr "Kan ikke finde en ledig vt"
 #: src/openvt.c:269
 #, c-format
 msgid "Cannot check whether vt %d is free; use `%s -f' to force."
-msgstr "Kan ikke undersøge om vt %d er ledig, brug '%s -f' at gennemtvinge."
+msgstr "Kan ikke undersÃ¸ge om vt %d er ledig, brug '%s -f' at gennemtvinge."
 
 #: src/openvt.c:273
 #, c-format
@@ -865,12 +865,12 @@ msgstr "Kunne ikke finde kommando"
 
 #: src/openvt.c:315
 msgid "Unable to set new session"
-msgstr "Kan ikke sætte ny session"
+msgstr "Kan ikke sÃ¦tte ny session"
 
 #: src/openvt.c:339
 #, c-format
 msgid "Unable to open %s"
-msgstr "Kan ikke åbne %s"
+msgstr "Kan ikke Ã¥bne %s"
 
 #: src/openvt.c:343
 #, c-format
@@ -880,7 +880,7 @@ msgstr "Bruger VT %s"
 #: src/openvt.c:349
 #, c-format
 msgid "Cannot open %s read/write"
-msgstr "Kan ikke åbne %s for læsning/skrivning"
+msgstr "Kan ikke Ã¥bne %s for lÃ¦sning/skrivning"
 
 #: src/openvt.c:361
 #, c-format
@@ -924,7 +924,7 @@ msgstr "%s: kort UCS-tabel\n"
 #: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
-msgstr "%s: Fejl ved læsning af inddataskrifttype"
+msgstr "%s: Fejl ved lÃ¦sning af inddataskrifttype"
 
 #: src/psffontop.c:229
 #, c-format
@@ -934,32 +934,32 @@ msgstr "%s: Fejlagtigt kald af readpsffont\n"
 #: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
-msgstr "%s: psf-filtilstand (%d) understøttes ikke\n"
+msgstr "%s: psf-filtilstand (%d) understÃ¸ttes ikke\n"
 
 #: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
-msgstr "%s: psf-version (%d) understøttes ikke\n"
+msgstr "%s: psf-version (%d) understÃ¸ttes ikke\n"
 
 #: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
-msgstr "%s: længde af inddataskrifttype er nul?\n"
+msgstr "%s: lÃ¦ngde af inddataskrifttype er nul?\n"
 
 #: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
-msgstr "%s: størrelse af inddatategn er nul?\n"
+msgstr "%s: stÃ¸rrelse af inddatategn er nul?\n"
 
 #: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
-msgstr "%s: Inddatafil: ugyldig inddatalængde (%d)\n"
+msgstr "%s: Inddatafil: ugyldig inddatalÃ¦ngde (%d)\n"
 
 #: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
-msgstr "%s: Inddatafil: efterfølgende snavs\n"
+msgstr "%s: Inddatafil: efterfÃ¸lgende snavs\n"
 
 #: src/psffontop.c:360
 #, c-format
@@ -994,7 +994,7 @@ msgstr "%s: Glyfnummer (0x%lx) forbi slutningen af skrifttypen\n"
 #: src/psfxtable.c:152
 #, c-format
 msgid "%s: Bad end of range (0x%lx)\n"
-msgstr "%s: Fejlagtigt slut på interval (0x%lx)\n"
+msgstr "%s: Fejlagtigt slut pÃ¥ interval (0x%lx)\n"
 
 #: src/psfxtable.c:171
 #, c-format
@@ -1045,7 +1045,7 @@ msgstr ""
 #: src/psfxtable.c:364
 #, c-format
 msgid "%s: Bad magic number on %s\n"
-msgstr "%s: Fejlagtigt magisk nummer på %s\n"
+msgstr "%s: Fejlagtigt magisk nummer pÃ¥ %s\n"
 
 #: src/psfxtable.c:383
 #, c-format
@@ -1079,13 +1079,13 @@ msgstr "Ugyldigt antal linjer\n"
 #: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
-msgstr "Gammel tilstand: %d×%d  Ny tilstand: %d×%d\n"
+msgstr "Gammel tilstand: %dÃ—%d  Ny tilstand: %dÃ—%d\n"
 
 #: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
-"Gammelt antal skanlinjer: %d  Nyt antal skanlinjer: %d  Tegnhøjde: %d\n"
+"Gammelt antal skanlinjer: %d  Nyt antal skanlinjer: %d  TegnhÃ¸jde: %d\n"
 
 #: src/resizecons.c:278
 #, c-format
@@ -1097,7 +1097,7 @@ msgstr "resizecons: kommandoen \"%s\" mislykkedes\n"
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
-"resizecons: glem ikke at ændre TERM (måske til con%dx%d eller linux-%dx%d)\n"
+"resizecons: glem ikke at Ã¦ndre TERM (mÃ¥ske til con%dx%d eller linux-%dx%d)\n"
 
 #: src/resizecons.c:378
 #, c-format
@@ -1115,7 +1115,7 @@ msgstr ""
 #: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
-msgstr "resizecons: kan ikke få I/O-rettigheder.\n"
+msgstr "resizecons: kan ikke fÃ¥ I/O-rettigheder.\n"
 
 #: src/screendump.c:51
 #, c-format
@@ -1125,26 +1125,26 @@ msgstr "brug: screendump [n]\n"
 #: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
-msgstr "Fejl ved læsning af %s\n"
+msgstr "Fejl ved lÃ¦sning af %s\n"
 
 #: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
-msgstr "kunne ikke læse %s, og kan ikke køre \"ioctl dump\"\n"
+msgstr "kunne ikke lÃ¦se %s, og kan ikke kÃ¸re \"ioctl dump\"\n"
 
 #: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
-msgstr "kunne ikke læse %s\n"
+msgstr "kunne ikke lÃ¦se %s\n"
 
 #: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
-msgstr "Mærkeligt ... skærmen er både %d×%d og %d×%d??\n"
+msgstr "MÃ¦rkeligt ... skÃ¦rmen er bÃ¥de %dÃ—%d og %dÃ—%d??\n"
 
 #: src/screendump.c:158
 msgid "Error writing screendump\n"
-msgstr "Fejl ved skrivning af skærmdump\n"
+msgstr "Fejl ved skrivning af skÃ¦rmdump\n"
 
 #: src/setfont.c:77
 #, c-format
@@ -1176,31 +1176,31 @@ msgid ""
 msgstr ""
 "Brug: setfont [skriveflag] [-<N>] [nyskrifttype..] [-m konsoltabel] [-u UCS-"
 "tabel]\n"
-"  skriveflag (sker før filer læses):\n"
-"    -o  <filnavn>\tSkriv nuværende skrifttype til <filnavn>\n"
-"    -O  <filnavn>\tSkriv nuværende skrifttype og UCS-tabel til <filnavn>\n"
-"    -om <filnavn>\tSkriv nuværende konsoltabel til <filnavn>\n"
-"    -ou <filnavn>\tSkriv nuværende UCS-tabel til <filnavn>\n"
+"  skriveflag (sker fÃ¸r filer lÃ¦ses):\n"
+"    -o  <filnavn>\tSkriv nuvÃ¦rende skrifttype til <filnavn>\n"
+"    -O  <filnavn>\tSkriv nuvÃ¦rende skrifttype og UCS-tabel til <filnavn>\n"
+"    -om <filnavn>\tSkriv nuvÃ¦rende konsoltabel til <filnavn>\n"
+"    -ou <filnavn>\tSkriv nuvÃ¦rende UCS-tabel til <filnavn>\n"
 "Hvis ingen \"nyskrifttype\" og ingen -[o|O|om|ou|m|u]-flag er givet,\n"
-"indlæses en standardskrifttype:\n"
-"    setfont             Indlæs skrifttype \"default[.gz]\"\n"
-"    setfont -<N>        Indlæs skrifttype \"default8x<N>[.gz]\"\n"
-"-<N>-flaget vælger en skrifttype fra en tegntabel som indeholder tre "
+"indlÃ¦ses en standardskrifttype:\n"
+"    setfont             IndlÃ¦s skrifttype \"default[.gz]\"\n"
+"    setfont -<N>        IndlÃ¦s skrifttype \"default8x<N>[.gz]\"\n"
+"-<N>-flaget vÃ¦lger en skrifttype fra en tegntabel som indeholder tre "
 "skrifttyper:\n"
-"    setfont -{8|14|16} codepage.cp[.gz]   Indlæs 8×<N>-skrifttypen fra "
+"    setfont -{8|14|16} codepage.cp[.gz]   IndlÃ¦s 8Ã—<N>-skrifttypen fra "
 "codepage.cp\n"
 "Eksplicit (med -m eller -u) eller implicit (i skrifttypefilen) givne "
 "tabeller\n"
-"vil blive læst ind og, hvis det er konsoltabeller, aktiveres.\n"
-"    -h<N>      (intet blanktegn) tilsidesæt skrifttypehøjde.\n"
-"    -m <fn>    Indlæs konsolskærmstabel.\n"
-"    -u <fn>    Indlæs UCS-skrifttypetabel.\n"
-"    -m none    Lad være med at indlæse og aktivere skærmtabel.\n"
-"    -u none    Lad være med at indlæse en UCS-tabel.\n"
-"    -v         Vær snaksalig.\n"
+"vil blive lÃ¦st ind og, hvis det er konsoltabeller, aktiveres.\n"
+"    -h<N>      (intet blanktegn) tilsidesÃ¦t skrifttypehÃ¸jde.\n"
+"    -m <fn>    IndlÃ¦s konsolskÃ¦rmstabel.\n"
+"    -u <fn>    IndlÃ¦s UCS-skrifttypetabel.\n"
+"    -m none    Lad vÃ¦re med at indlÃ¦se og aktivere skÃ¦rmtabel.\n"
+"    -u none    Lad vÃ¦re med at indlÃ¦se en UCS-tabel.\n"
+"    -v         VÃ¦r snaksalig.\n"
 "    -C <cons>  Angiv konsolenhed der skal bruges\n"
 "    -V         Udskriv version og afslut.\n"
-"Filer indlæses fra det aktuelle katalog eller %s/*/.\n"
+"Filer indlÃ¦ses fra det aktuelle katalog eller %s/*/.\n"
 
 #: src/setfont.c:180
 #, c-format
@@ -1213,12 +1213,12 @@ msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
 "unchanged.\n"
 msgstr ""
-"setfont: kan ikke både genskabe fra tegn-ROM og fra fil. Fonten uændret.\n"
+"setfont: kan ikke bÃ¥de genskabe fra tegn-ROM og fra fil. Fonten uÃ¦ndret.\n"
 
 #: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
-msgstr "Fejlagtig tegnhøjde %d\n"
+msgstr "Fejlagtig tegnhÃ¸jde %d\n"
 
 #: src/setfont.c:267
 #, c-format
@@ -1238,27 +1238,27 @@ msgstr "%s: rensede det\n"
 #: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
-msgstr "%s: baggrunden vil se mærkelig ud\n"
+msgstr "%s: baggrunden vil se mÃ¦rkelig ud\n"
 
 #: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
-msgstr "Indlæser %d-tegns %d×%d-skrifttype fra filen %s\n"
+msgstr "IndlÃ¦ser %d-tegns %dÃ—%d-skrifttype fra filen %s\n"
 
 #: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
-msgstr "Indlæser %d-tegns %d×%d-skrifttype\n"
+msgstr "IndlÃ¦ser %d-tegns %dÃ—%d-skrifttype\n"
 
 #: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
-msgstr "Indlæser %d-tegns %d×%d-skrifttype (%d) fra filen %s\n"
+msgstr "IndlÃ¦ser %d-tegns %dÃ—%d-skrifttype (%d) fra filen %s\n"
 
 #: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
-msgstr "Indlæser %d-tegns %d×%d-skrifttype (%d)\n"
+msgstr "IndlÃ¦ser %d-tegns %dÃ—%d-skrifttype (%d)\n"
 
 #: src/setfont.c:379
 #, c-format
@@ -1268,34 +1268,34 @@ msgstr "%s: fejl i do_loadtable\n"
 #: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
-msgstr "Indlæser UCS-konverteringsstabel...\n"
+msgstr "IndlÃ¦ser UCS-konverteringsstabel...\n"
 
 #: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
-msgstr "Kan ikke åbne skrifttypefilen %s\n"
+msgstr "Kan ikke Ã¥bne skrifttypefilen %s\n"
 
 #: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
-"Når flere skrifttyper læses ind skal alle være psf-skrifttyper - %s er det "
+"NÃ¥r flere skrifttyper lÃ¦ses ind skal alle vÃ¦re psf-skrifttyper - %s er det "
 "ikke\n"
 
 #: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
-msgstr "Læste %d-tegns %d×%d-skrifttype fra filen %s\n"
+msgstr "LÃ¦ste %d-tegns %dÃ—%d-skrifttype fra filen %s\n"
 
 #: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
-msgstr "Når flere skrifttyper læses ind skal alle have samme højde\n"
+msgstr "NÃ¥r flere skrifttyper lÃ¦ses ind skal alle have samme hÃ¸jde\n"
 
 #: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
-msgstr "Når flere skrifttyper læses ind skal alle have samme bredde\n"
+msgstr "NÃ¥r flere skrifttyper lÃ¦ses ind skal alle have samme bredde\n"
 
 #: src/setfont.c:518
 #, c-format
@@ -1310,7 +1310,7 @@ msgstr "Kan ikke finde skrifttypen %s\n"
 #: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
-msgstr "Læser skrifttypefilen %s\n"
+msgstr "LÃ¦ser skrifttypefilen %s\n"
 
 #: src/setfont.c:581
 #, c-format
@@ -1325,12 +1325,12 @@ msgstr "For mange filer at kombinere\n"
 #: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
-msgstr "Hmm - en skrifttype fra restorefont? Bruger første halvdel.\n"
+msgstr "Hmm - en skrifttype fra restorefont? Bruger fÃ¸rste halvdel.\n"
 
 #: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
-msgstr "Fejlagtig størrelse på inddatafilen\n"
+msgstr "Fejlagtig stÃ¸rrelse pÃ¥ inddatafilen\n"
 
 #: src/setfont.c:650
 #, c-format
@@ -1338,14 +1338,14 @@ msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
 "using an option -8 or -14 or -16 which one you want loaded.\n"
 msgstr ""
-"Denne fil indeholder 3 skrifttyper: 8×8, 8×14 og 8×16. Vælg hvilken\n"
-"du vil indlæse via et af flagene -8, -14 eller -16.\n"
+"Denne fil indeholder 3 skrifttyper: 8Ã—8, 8Ã—14 og 8Ã—16. VÃ¦lg hvilken\n"
+"du vil indlÃ¦se via et af flagene -8, -14 eller -16.\n"
 
 #: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
-"Du bad om skrifttypesstørrelsen %d, men kun 8, 14 og 16 er mulige her.\n"
+"Du bad om skrifttypesstÃ¸rrelsen %d, men kun 8, 14 og 16 er mulige her.\n"
 
 #: src/setfont.c:713
 #, c-format
@@ -1355,7 +1355,7 @@ msgstr "Fandt ikke noget at gemme\n"
 #: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
-msgstr "Gemte %d-tegns %d×%d-skrifttypefil til %s\n"
+msgstr "Gemte %d-tegns %dÃ—%d-skrifttypefil til %s\n"
 
 #: src/setkeycodes.c:25
 #, c-format
@@ -1364,8 +1364,8 @@ msgid ""
 " (where scancode is either xx or e0xx, given in hexadecimal,\n"
 "  and keycode is given in decimal)\n"
 msgstr ""
-"brug: setkeycode aflæsningskode tastekode ...\n"
-" (hvor aflæsningskode er enten xx eller e0xx angivet heksadecimalt,\n"
+"brug: setkeycode aflÃ¦sningskode tastekode ...\n"
+" (hvor aflÃ¦sningskode er enten xx eller e0xx angivet heksadecimalt,\n"
 "  og tastekode er angivet decimalt)\n"
 
 #: src/setkeycodes.c:47
@@ -1374,16 +1374,16 @@ msgstr "lige antal argumenter forventedes"
 
 #: src/setkeycodes.c:56
 msgid "error reading scancode"
-msgstr "fejl ved læsning af aflæsningskode"
+msgstr "fejl ved lÃ¦sning af aflÃ¦sningskode"
 
 #: src/setkeycodes.c:64
 msgid "code outside bounds"
-msgstr "kode uden for grænserne"
+msgstr "kode uden for grÃ¦nserne"
 
 #: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
-msgstr "kunne ikke sætte aflæsningskoden %x til tastekoden %d\n"
+msgstr "kunne ikke sÃ¦tte aflÃ¦sningskoden %x til tastekoden %d\n"
 
 #: src/setleds.c:25
 #, c-format
@@ -1405,14 +1405,14 @@ msgstr ""
 "\tsetleds [-v] [-L] [-D] [-F] [[+|-][ num | caps | scroll %s]]\n"
 "Dvs,\n"
 "\tsetleds +caps -num\n"
-"vil sætte capslock, rydde numlock og beholde scrollock uændret.\n"
-"Indstillingerne før og efter ændring (om nogen) rapporteres når\n"
-"-v-flaget er givet eller når ingen ændringer forespørges.\n"
-"Normalt påvirker setleds vt-flagindstillingerne\n"
+"vil sÃ¦tte capslock, rydde numlock og beholde scrollock uÃ¦ndret.\n"
+"Indstillingerne fÃ¸r og efter Ã¦ndring (om nogen) rapporteres nÃ¥r\n"
+"-v-flaget er givet eller nÃ¥r ingen Ã¦ndringer forespÃ¸rges.\n"
+"Normalt pÃ¥virker setleds vt-flagindstillingerne\n"
 "(og dette vises normalt i dioderne).\n"
-"Med -L sætter setleds dioderne og påvirker ikke flagene.\n"
-"Med -D sættes både flagene og standardflagene så senere\n"
-"nulstillinger ikke vil ændre flagene.\n"
+"Med -L sÃ¦tter setleds dioderne og pÃ¥virker ikke flagene.\n"
+"Med -D sÃ¦ttes bÃ¥de flagene og standardflagene sÃ¥ senere\n"
+"nulstillinger ikke vil Ã¦ndre flagene.\n"
 
 #: src/setleds.c:46
 msgid "on "
@@ -1427,7 +1427,7 @@ msgstr "fra"
 msgid ""
 "Error reading current led setting. Maybe stdin is not a VT?: ioctl KDGETLED"
 msgstr ""
-"Fejl ved læsning af nuværende indstilling. Standard ind er måske ikke en "
+"Fejl ved lÃ¦sning af nuvÃ¦rende indstilling. Standard ind er mÃ¥ske ikke en "
 "VT?\n"
 
 #: src/setleds.c:110
@@ -1436,26 +1436,26 @@ msgid ""
 "Error reading current flags setting. Maybe you are not on the console?: "
 "ioctl KDGKBLED"
 msgstr ""
-"Fejl ved læsning af nuværende flagindstilling. Du er måske ikke på "
+"Fejl ved lÃ¦sning af nuvÃ¦rende flagindstilling. Du er mÃ¥ske ikke pÃ¥ "
 "konsollen?\n"
 
 #: src/setleds.c:129
 #, fuzzy
 msgid "Error reading current led setting from /dev/kbd: ioctl KIOCGLED"
-msgstr "Fejl ved læsning af nuværende diodeindstilling fra /dev/kbd.\n"
+msgstr "Fejl ved lÃ¦sning af nuvÃ¦rende diodeindstilling fra /dev/kbd.\n"
 
 #: src/setleds.c:133
 msgid "KIOCGLED unavailable?\n"
-msgstr "KIOCGLED ikke tilgængelig?\n"
+msgstr "KIOCGLED ikke tilgÃ¦ngelig?\n"
 
 #: src/setleds.c:148
 #, fuzzy
 msgid "Error reading current led setting from /dev/kbd: ioctl KIOCSLED"
-msgstr "Fejl ved læsning af nuværende diodeindstilling fra /dev/kbd.\n"
+msgstr "Fejl ved lÃ¦sning af nuvÃ¦rende diodeindstilling fra /dev/kbd.\n"
 
 #: src/setleds.c:152
 msgid "KIOCSLED unavailable?\n"
-msgstr "KIOCSLED ikke tilgængelig?\n"
+msgstr "KIOCSLED ikke tilgÃ¦ngelig?\n"
 
 #: src/setleds.c:208
 msgid "Error resetting ledmode\n"
@@ -1464,17 +1464,17 @@ msgstr "Fejl ved nulstilling af diodetilstand\n"
 #: src/setleds.c:216
 #, c-format
 msgid "Current default flags:  "
-msgstr "Nuværende standardflag:  "
+msgstr "NuvÃ¦rende standardflag:  "
 
 #: src/setleds.c:220
 #, c-format
 msgid "Current flags:          "
-msgstr "Nuværende flag:          "
+msgstr "NuvÃ¦rende flag:          "
 
 #: src/setleds.c:224
 #, c-format
 msgid "Current leds:           "
-msgstr "Nuværende dioder:           "
+msgstr "NuvÃ¦rende dioder:           "
 
 #: src/setleds.c:260 src/setmetamode.c:96
 #, c-format
@@ -1526,30 +1526,30 @@ msgid ""
 "The setting before and after the change are reported.\n"
 msgstr ""
 "Brug:\n"
-"\tsetmetamode [ metabit | meta | bit | escpræfiks | esc | præfiks ]\n"
+"\tsetmetamode [ metabit | meta | bit | escprÃ¦fiks | esc | prÃ¦fiks ]\n"
 "Hver vt har sin egen kopi af denne bit. Brug\n"
 "\tsetmetamode [arg] < /dev/ttyn\n"
-"for at ændre indstillingen for en anden vt.\n"
-"Indstillingen for og efter ændringen rapporteres.\n"
+"for at Ã¦ndre indstillingen for en anden vt.\n"
+"Indstillingen for og efter Ã¦ndringen rapporteres.\n"
 
 #: src/setmetamode.c:40
 msgid "Meta key sets high order bit\n"
-msgstr "Metatasten sætter højeste bit\n"
+msgstr "Metatasten sÃ¦tter hÃ¸jeste bit\n"
 
 #: src/setmetamode.c:43
 msgid "Meta key gives Esc prefix\n"
-msgstr "Metatasten giver esc-præfiks\n"
+msgstr "Metatasten giver esc-prÃ¦fiks\n"
 
 #: src/setmetamode.c:46
 msgid "Strange mode for Meta key?\n"
-msgstr "Mærkelig tilstand for Metatasten?\n"
+msgstr "MÃ¦rkelig tilstand for Metatasten?\n"
 
 #: src/setmetamode.c:80
 #, fuzzy
 msgid ""
 "Error reading current setting. Maybe stdin is not a VT?: ioctl KDGKBMETA"
 msgstr ""
-"Fejl ved læsning af nuværende indstilling. Standard ind er måske ikke en "
+"Fejl ved lÃ¦sning af nuvÃ¦rende indstilling. Standard ind er mÃ¥ske ikke en "
 "VT?\n"
 
 #: src/setmetamode.c:100
@@ -1588,24 +1588,24 @@ msgid ""
 msgstr ""
 "Brug: %s vga|FIL|-\n"
 "\n"
-"Hvis du bruger FIL-parametren, bør FIL være nøjagtig 3 linjer med\n"
-"komma-separerede decimale værdier for RØD, GRØN og BLÅ.\n"
+"Hvis du bruger FIL-parametren, bÃ¸r FIL vÃ¦re nÃ¸jagtig 3 linjer med\n"
+"komma-separerede decimale vÃ¦rdier for RÃ˜D, GRÃ˜N og BLÃ….\n"
 "\n"
 "For at starte en gyldig FIL:\n"
 "   cat /sys/module/vt/parameters/default_{red,grn,blu} > FIL\n"
 "\n"
-"og redigér så værdierne i FIL.\n"
+"og redigÃ©r sÃ¥ vÃ¦rdierne i FIL.\n"
 "\n"
 
 #: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
-msgstr "Fejl: %s: Ugyldig værdi i felt %u i linje %u."
+msgstr "Fejl: %s: Ugyldig vÃ¦rdi i felt %u i linje %u."
 
 #: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
-msgstr "Fejl: %s: Utilstrækkeligt antal felter i linje %u."
+msgstr "Fejl: %s: UtilstrÃ¦kkeligt antal felter i linje %u."
 
 #: src/setvtrgb.c:86
 #, c-format
@@ -1619,7 +1619,7 @@ msgstr "Fejl: %s: linje %u er for lang.\n"
 
 #: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
-msgstr "mislykkedes med at genskabe originaloversætningstabellen\n"
+msgstr "mislykkedes med at genskabe originaloversÃ¦tningstabellen\n"
 
 #: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
@@ -1627,7 +1627,7 @@ msgstr "mislykkedes med at genskabe originalucstabel\n"
 
 #: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
-msgstr "kan ikke ændre oversætningstabellen\n"
+msgstr "kan ikke Ã¦ndre oversÃ¦tningstabellen\n"
 
 #: src/showconsolefont.c:101
 #, fuzzy, c-format
@@ -1645,14 +1645,14 @@ msgid ""
 msgstr ""
 "brug: showconsolefont -V|--version\n"
 "       showconsolefont [-C tty] [-v] [-i]\n"
-"(formentligt efter at have indlæst en skrifttype med `setfont font')\n"
+"(formentligt efter at have indlÃ¦st en skrifttype med `setfont font')\n"
 "\n"
 "Gyldige tilvalg er:\n"
-" -C tty   Enhed du vil læse skrifttypen fra. Standard: Aktuel Konsol-enhed "
+" -C tty   Enhed du vil lÃ¦se skrifttypen fra. Standard: Aktuel Konsol-enhed "
 "(tty).\n"
-" -v       Vær mere snaksaglig.\n"
+" -v       VÃ¦r mere snaksaglig.\n"
 " -i       Udskriv ikke skrifttypetabellen, bare vis\n"
-"          RÆKKERxKOLONNExANTAL og afslut.\n"
+"          RÃ†KKERxKOLONNExANTAL og afslut.\n"
 
 #: src/showconsolefont.c:170
 #, c-format
@@ -1667,7 +1667,7 @@ msgstr "Skrifttypebredde : %d\n"
 #: src/showconsolefont.c:172
 #, c-format
 msgid "Font height    : %d\n"
-msgstr "Skrifttypehøjde  : %d\n"
+msgstr "SkrifttypehÃ¸jde  : %d\n"
 
 #: src/showconsolefont.c:183
 #, c-format
@@ -1693,8 +1693,8 @@ msgid ""
 "[ if you are trying this under X, it might not work\n"
 "since the X server is also reading /dev/console ]\n"
 msgstr ""
-"[ hvis du gør dette i X så fungerer det måske ikke \n"
-"da X-serveren også læser /dev/console ]\n"
+"[ hvis du gÃ¸r dette i X sÃ¥ fungerer det mÃ¥ske ikke \n"
+"da X-serveren ogsÃ¥ lÃ¦ser /dev/console ]\n"
 
 #: src/showkey.c:74
 #, c-format
@@ -1722,9 +1722,9 @@ msgstr ""
 "\n"
 "tilladte flag er:\n"
 "\n"
-"\t-h --help\tvis denne hjælpeteksten\n"
-"\t-a --ascii\tvis decimale/oktale/heksadecimale værdier for tasterne\n"
-"\t-s --scancodes\tvis kun de rå skankoder\n"
+"\t-h --help\tvis denne hjÃ¦lpeteksten\n"
+"\t-a --ascii\tvis decimale/oktale/heksadecimale vÃ¦rdier for tasterne\n"
+"\t-s --scancodes\tvis kun de rÃ¥ skankoder\n"
 "\t-k --keycodes\tvis kun de tolkede tastekoder (standard)\n"
 
 #: src/showkey.c:171
@@ -1735,14 +1735,14 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Tryk en vilkårlig tast - Ctrl-D vil afslutte programmet\n"
+"Tryk en vilkÃ¥rlig tast - Ctrl-D vil afslutte programmet\n"
 "\n"
 
 #: src/showkey.c:239
 #, c-format
 msgid "press any key (program terminates 10s after last keypress)...\n"
 msgstr ""
-"tryk en vilkårlig tast (programmet afsluttes 10 s efter sidste "
+"tryk en vilkÃ¥rlig tast (programmet afsluttes 10 s efter sidste "
 "tastetrykning)...\n"
 
 #: src/showkey.c:263
@@ -1848,7 +1848,7 @@ msgstr "%s: VT 1 er konsollen og kan ikke deallokeres\n"
 #~ msgstr "Advarsel: stien er for lang: %s/%s\n"
 
 #~ msgid "kbd_mode: error reading keyboard mode\n"
-#~ msgstr "kbd_mode: fejl ved læsning af tastaturstilstand\n"
+#~ msgstr "kbd_mode: fejl ved lÃ¦sning af tastaturstilstand\n"
 
 #~ msgid "%s: error setting keyboard mode\n"
 #~ msgstr "%s: fejl da tastaturstilstand sattes\n"
@@ -1860,40 +1860,40 @@ msgstr "%s: VT 1 er konsollen og kan ikke deallokeres\n"
 #~ msgstr "skifter til %s\n"
 
 #~ msgid "cannot open include file %s"
-#~ msgstr "Kan ikke åbne inkluderingsfilen %s"
+#~ msgstr "Kan ikke Ã¥bne inkluderingsfilen %s"
 
 #~ msgid "expected filename between quotes"
-#~ msgstr "forventede filnavn i anførselstegn"
+#~ msgstr "forventede filnavn i anfÃ¸rselstegn"
 
 #~ msgid "unicode keysym out of range: %s"
-#~ msgstr "UCS keysym uden for område: %s"
+#~ msgstr "UCS keysym uden for omrÃ¥de: %s"
 
 #~ msgid "string too long"
 #~ msgstr "strengen er for lang"
 
 #~ msgid "addmap called with bad index %d"
-#~ msgstr "addmap kaldt ,ed dårligt indeks %d"
+#~ msgstr "addmap kaldt ,ed dÃ¥rligt indeks %d"
 
 #~ msgid "killkey called with bad index %d"
-#~ msgstr "killkey kaldt med dårligt indeks %d"
+#~ msgstr "killkey kaldt med dÃ¥rligt indeks %d"
 
 #~ msgid "killkey called with bad table %d"
-#~ msgstr "killkey kaldt med dårlig tabel %d"
+#~ msgstr "killkey kaldt med dÃ¥rlig tabel %d"
 
 #~ msgid "addkey called with bad index %d"
-#~ msgstr "addkey kaldt med dårligt indeks %d"
+#~ msgstr "addkey kaldt med dÃ¥rligt indeks %d"
 
 #~ msgid "addkey called with bad table %d"
-#~ msgstr "addkey kaldt med dårlig tabel %d"
+#~ msgstr "addkey kaldt med dÃ¥rlig tabel %d"
 
 #~ msgid "%s: addfunc called with bad func %d\n"
-#~ msgstr "%s: addfunc kaldt med dårlig func %d\n"
+#~ msgstr "%s: addfunc kaldt med dÃ¥rlig func %d\n"
 
 #~ msgid "%s: addfunc: func_buf overflow\n"
-#~ msgstr "%s: addfunc: overløb i func_buf\n"
+#~ msgstr "%s: addfunc: overlÃ¸b i func_buf\n"
 
 #~ msgid "compose table overflow\n"
-#~ msgstr "overløb i kompositionstabel\n"
+#~ msgstr "overlÃ¸b i kompositionstabel\n"
 
 #~ msgid "key"
 #~ msgstr "tast"
@@ -1908,7 +1908,7 @@ msgstr "%s: VT 1 er konsollen og kan ikke deallokeres\n"
 #~ msgstr "strenge"
 
 #~ msgid "Loaded %d compose %s.\n"
-#~ msgstr "Indlæste %d kompositionér %s\n"
+#~ msgstr "IndlÃ¦ste %d kompositionÃ©r %s\n"
 
 #~ msgid "definition"
 #~ msgstr "definition"
@@ -1917,31 +1917,31 @@ msgstr "%s: VT 1 er konsollen og kan ikke deallokeres\n"
 #~ msgstr "definitioner"
 
 #~ msgid "loadkeys: don't know how to compose for %s\n"
-#~ msgstr "loadkeys: véd ikke hvordan at kompositionere for %s\n"
+#~ msgstr "loadkeys: vÃ©d ikke hvordan at kompositionere for %s\n"
 
 #~ msgid "'%s' is not a function key symbol"
 #~ msgstr "'%s' er ikke et symbol for en funktionstast"
 
 #~ msgid "too many (%d) entries on one line"
-#~ msgstr "For mange (%d) indgange på én linje"
+#~ msgstr "For mange (%d) indgange pÃ¥ Ã©n linje"
 
 #~ msgid "too many key definitions on one line"
-#~ msgstr "for mane definitioner for taster på én linje"
+#~ msgstr "for mane definitioner for taster pÃ¥ Ã©n linje"
 
 #~ msgid "Searching in %s\n"
-#~ msgstr "Søger i %s\n"
+#~ msgstr "SÃ¸ger i %s\n"
 
 #~ msgid "Loading %s\n"
-#~ msgstr "Indlæser %s\n"
+#~ msgstr "IndlÃ¦ser %s\n"
 
 #~ msgid "syntax error in map file\n"
 #~ msgstr "Syntaksfejl i tabelfil\n"
 
 #~ msgid "key bindings not changed\n"
-#~ msgstr "tastebininger ikke ændret\n"
+#~ msgstr "tastebininger ikke Ã¦ndret\n"
 
 #~ msgid "Error opening /dev/kbd.\n"
-#~ msgstr "Fejl ved åbning af /dev/kbd.\n"
+#~ msgstr "Fejl ved Ã¥bning af /dev/kbd.\n"
 
 #~ msgid "%s: out of memory?\n"
-#~ msgstr "%s: slut på hukommelsen?\n"
+#~ msgstr "%s: slut pÃ¥ hukommelsen?\n"

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd-1.15.3-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2011-06-03 22:01+0200\n"
 "Last-Translator: Keld Simonsen <keld@keldix.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -19,47 +19,47 @@ msgstr ""
 "X-Generator: KBabel 1.11.4\n"
 "Plural-Forms:  nplurals=2; plural=(n != 1);\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "brug: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Kunne ikke få en filidentifikator der refererer til konsollen"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: ukendt flag\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s: 0: ugyldigt VT-nummer\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s: VT 1 er konsollen og kan ikke deallokeres\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s: kunne ikke deallokere konsol %d\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys version %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -95,7 +95,7 @@ msgstr ""
 "\t   --compose­only   vis kun \"compose\"-tastekombinationer\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -104,24 +104,24 @@ msgstr ""
 "\t\t\t    tolk tegnhandlingskoder som om de er fra det\n"
 "\t\t\t    angivne tegnsæt\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "ukendt tegnsæt %s - ignorerer anmodning om tegnsæt\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: fejl ved læsning af tastaturstilstand\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -132,7 +132,7 @@ msgstr ""
 "(numerisk værdi, symbol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -155,42 +155,32 @@ msgstr ""
 "\t-V --version         vis versionsnummer\n"
 "\t-n --next-available  vis nummer på næste utildelte VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Kunne ikke læse VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Kunne ikke åbne %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Kunne ikke få en filidentifikator der referere til konsollen\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "brug: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Enkle aflæsningskoder xx (hex) mod tastekoder (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 er en fejl, for 1-88 (0x01-0x58) er aflæsningskoden lig med tastekoden\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "for 1-%d (0x01-0x%02x) er aflæsningskoden lig med tastekoden\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -201,12 +191,12 @@ msgstr ""
 "\n"
 "Udvidede aflæsningskoder e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "mislykkedes med at hente tastekoden for aflæsningskode 0x%x\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -240,71 +230,71 @@ msgstr "Fejl: Ikke nok argumenter.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Fejl: Ukendt handling: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "brug: kbd_mode [-a|-u|-k|-s] [-C enhed]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Tastaturet er i rå (aflæsningskode-)tilstand\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Tastaturet er i halvrå (tastekode-)tilstand\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Tastaturet er i standardtilstand (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Tastaturet er i UCS-tilstand (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Tastaturet er i en ukendt tilstand\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Gentagelseshastighed sat til %.1f t/s (forsinkelse = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Brug: kbdrate [-V] [-s] [-r frekvens] [-d forsinkelse]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Kan ikke åbne /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "fejl: getfont kaldt med count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "fejl: getfont med GIO_FONT behøver buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: hukommelsen slut\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "mærkeligt... ct ændredes fra %d til %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -313,23 +303,38 @@ msgstr ""
 "Det ser ud til at denne kerne er ældre end 1.1.92\n"
 "Ingen UCS-tabel indlæst.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Kunne ikke åbne %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Kunne ikke få en filidentifikator der referere til konsollen\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s fra %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s: hukommelsen slut\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "Fejl ved skrivning af tabel til fil\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "umuligt: ikke meta?\n"
@@ -349,72 +354,72 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, fuzzy, c-format
 msgid "unable to get keymap %d"
 msgstr "deallokér keymap %d\n"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "kunne ikke binde tast %d til værdien %d\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, fuzzy, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "addkey kaldt med dårlig keycode %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "tilføjelse af tabel %d strider mod eksplicit keymaps-linje"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr "kunne ikke binde tast %d til værdien %d\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 #, fuzzy
 msgid "impossible error in lk_add_constants"
 msgstr "umulig fejl i do_constant"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "antager iso-8859-1 %s\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "antager iso-8859-15 %s\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "antager iso-8859-2 %s\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "antager iso-8859-3 %s\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "antager iso-8859-4 %s\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "ukendt tegnsymbol \"%s\"\n"
@@ -463,12 +468,12 @@ msgstr "%s: kan ikke deallokere eller nulstille keymap\n"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "%s: kunne ikke gå tilbage til oprindelig tastatyrtilstand\n"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, fuzzy, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "mislykkedes med at binde stren '%s' til funktion %s\n"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, fuzzy, c-format
 msgid "failed to clear string %s"
 msgstr "mislykkedes med at nulstille streng %s\n"
@@ -478,7 +483,7 @@ msgstr "mislykkedes med at nulstille streng %s\n"
 msgid "too many compose definitions"
 msgstr "for mange kompositionsdefinitioner\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -489,7 +494,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, fuzzy, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -500,14 +505,14 @@ msgstr[1] ""
 "\n"
 "Ændrede %d %s og %d %s.\n"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "for mange kompositionsdefinitioner\n"
 msgstr[1] "for mange kompositionsdefinitioner\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "(Ingen ændringer i kompositionsdefinitioner)\n"
@@ -577,7 +582,7 @@ msgstr ""
 "\n"
 "Genkendte ændrernavn og deres kolonnenummer:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, fuzzy, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -620,17 +625,12 @@ msgstr ""
 "  -u --unicode       gennemtving konvertering til UCS\n"
 "  -v --verbose       udskriv ændringerne\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s fra %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: Tilvalg --unicode og --ascii er gensidigt udelukkende\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -639,7 +639,7 @@ msgstr ""
 "%s: advarsel: indlæser ikke-UCS keymap på UCS konsol\n"
 "    (måske vil du gerne lave 'kbd_mode -a'?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -648,17 +648,17 @@ msgstr ""
 "%s: advarsel: indlæser UCS keymap på ikke-UCS konsol\n"
 "    (måske vil du gerne lave 'kbd_mode -u'?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Kan ikke finde %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "Kan ikke åbne fil %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -667,29 +667,29 @@ msgstr ""
 "Brug:\n"
 "\t%s [-C konsol] [-o map.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Fejlagtig inddatalinje: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Tegnnummer (0x%x) større end skrifttypelængde\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Fejlagtigt slut på interval (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Fejlagtigt UCS-interval som modsvarer skrifttypepositionsinterval 0x%x-0x"
 "%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -698,22 +698,22 @@ msgstr ""
 "%s: UCS-interval U+%x-U+%x er ikke af samme længde som "
 "skrifttypespositionsinterval 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: efterfølgende snavs (%s) ignoreret\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Indlæser UCS-tabel fra fil %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Advarsel: linjen er for lang\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -722,85 +722,85 @@ msgstr ""
 "%s: indlæser ikke tom ucs-tabel\n"
 "(hvis du insisterer: brug flaget -f til at tilsidesætte)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "post"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "poster"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Gemte ucs-tabel til \"%s\"\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Tilføjede UCS-tabel\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "brug: %s [-v] [-o originaltabel] tabelfil\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: kan ikke åbne tabelfil _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Kan ikke tage status på tabelfil"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Indlæser binær direkte-til-skrifttype-skærmtabel fra fil %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Fejl ved læsning af tabel fra fil \"%s\"\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Indlæser binær UCS-skærmfil fra fil %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Indlæser symbolsk skærmtabel fra fil %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Fejl ved tolkning af symbolsk tabel fra \"%s\", linje %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Fejl ved skrivning af tabel til fil\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Kan ikke læse konsoltabel\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Gemte skærmtabel i \"%s\"\n"
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -832,11 +832,11 @@ msgstr ""
 "  -h, --help          udskriv en kort hjælpetekst.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Kunne ikke finde ejer af aktuel tty!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: Ugyldigt vt-nummer"
@@ -882,96 +882,96 @@ msgstr "Bruger VT %s"
 msgid "Cannot open %s read/write"
 msgstr "Kan ikke åbne %s for læsning/skrivning"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Kunne ikke aktivere vt %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Aktivering afbrudt?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Kunne ikke deallokere konsol %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: kort ucs2-tabel\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: kort utf8-tabel\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: fejlagtig utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: ukendt utf8-fejl\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: kort UCS-tabel\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Fejl ved læsning af inddataskrifttype"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Fejlagtigt kald af readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: psf-filtilstand (%d) understøttes ikke\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: psf-version (%d) understøttes ikke\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: længde af inddataskrifttype er nul?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: størrelse af inddatategn er nul?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Inddatafil: ugyldig inddatalængde (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Inddatafil: efterfølgende snavs\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: ugyldig UCS %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Kan ikke skrive skrifttypefilhoved"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Kan ikke skrive til skrifttypefilen"
@@ -1057,39 +1057,49 @@ msgstr "%s: psf-fil med ukendt magisk nummer\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: inddataskrifttypen har ikke noget indeks\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: kan ikke finde videotilstandsfil %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: kan ikke finde videotilstandsfil %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Ugyldigt antal linjer\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Gammel tilstand: %d×%d  Ny tilstand: %d×%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 "Gammelt antal skanlinjer: %d  Nyt antal skanlinjer: %d  Tegnhøjde: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: kommandoen \"%s\" mislykkedes\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: glem ikke at ændre TERM (måske til con%dx%d eller linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1102,41 +1112,41 @@ msgstr ""
 "eller: resizecons -lines LINJER, hvor LINJER er en af 25, 28, 30, 34, 36, "
 "40, 44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: kan ikke få I/O-rettigheder.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "brug: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "Fejl ved læsning af %s\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "kunne ikke læse %s, og kan ikke køre \"ioctl dump\"\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "kunne ikke læse %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Mærkeligt ... skærmen er både %d×%d og %d×%d??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Fejl ved skrivning af skærmdump\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1192,12 +1202,12 @@ msgstr ""
 "    -V         Udskriv version og afslut.\n"
 "Filer indlæses fra det aktuelle katalog eller %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: for mange inddatafiler\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1205,124 +1215,124 @@ msgid ""
 msgstr ""
 "setfont: kan ikke både genskabe fra tegn-ROM og fra fil. Fonten uændret.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Fejlagtig tegnhøjde %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Fejlagtig tegnbredde %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: Skrifttypesposition 32 er ikke-blank\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: rensede det\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: baggrunden vil se mærkelig ud\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Indlæser %d-tegns %d×%d-skrifttype fra filen %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Indlæser %d-tegns %d×%d-skrifttype\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Indlæser %d-tegns %d×%d-skrifttype (%d) fra filen %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Indlæser %d-tegns %d×%d-skrifttype (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: fejl i do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Indlæser UCS-konverteringsstabel...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Kan ikke åbne skrifttypefilen %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Når flere skrifttyper læses ind skal alle være psf-skrifttyper - %s er det "
 "ikke\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Læste %d-tegns %d×%d-skrifttype fra filen %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Når flere skrifttyper læses ind skal alle have samme højde\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "Når flere skrifttyper læses ind skal alle have samme bredde\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Kan ikke finde standardskrifttypen\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Kan ikke finde skrifttypen %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Læser skrifttypefilen %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Intet endeligt nylinjestegn i kombinationsfilen\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "For mange filer at kombinere\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - en skrifttype fra restorefont? Bruger første halvdel.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Fejlagtig størrelse på inddatafilen\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1331,23 +1341,23 @@ msgstr ""
 "Denne fil indeholder 3 skrifttyper: 8×8, 8×14 og 8×16. Vælg hvilken\n"
 "du vil indlæse via et af flagene -8, -14 eller -16.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Du bad om skrifttypesstørrelsen %d, men kun 8, 14 og 16 er mulige her.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Fandt ikke noget at gemme\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Gemte %d-tegns %d×%d-skrifttypefil til %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1358,19 +1368,19 @@ msgstr ""
 " (hvor aflæsningskode er enten xx eller e0xx angivet heksadecimalt,\n"
 "  og tastekode er angivet decimalt)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "lige antal argumenter forventedes"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "fejl ved læsning af aflæsningskode"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "kode uden for grænserne"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "kunne ikke sætte aflæsningskoden %x til tastekoden %d\n"
@@ -1552,12 +1562,12 @@ msgstr "gammel tilstand:    "
 msgid "new state:    "
 msgstr "ny tilstand:       "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "brug: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1587,39 +1597,39 @@ msgstr ""
 "og redigér så værdierne i FIL.\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Fejl: %s: Ugyldig værdi i felt %u i linje %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Fejl: %s: Utilstrækkeligt antal felter i linje %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Fejl: %s: linje %u afsluttedes uventet.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Fejl: %s: linje %u er for lang.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "mislykkedes med at genskabe originaloversætningstabellen\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "mislykkedes med at genskabe originalucstabel\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "kan ikke ændre oversætningstabellen\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1668,16 +1678,16 @@ msgstr ""
 "Viser %d-tegns skrifttype\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?UKENDT?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "tgb-tilstand var %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1686,12 +1696,12 @@ msgstr ""
 "[ hvis du gør dette i X så fungerer det måske ikke \n"
 "da X-serveren også læser /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "fik signalet %d, rydder op...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1748,28 +1758,28 @@ msgstr "tryk"
 msgid "keycode %3d %s\n"
 msgstr "tastekode %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "brug: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1778,7 +1788,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1799,16 +1809,16 @@ msgstr ""
 "ukendt argument: _%s_\n"
 "\n"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "%s: VT 1 er konsollen og kan ikke deallokeres\n"

--- a/po/de.po
+++ b/po/de.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-12-28 12:59+0100\n"
 "Last-Translator: Mario Blättermann <mario.blaettermann@gmail.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -28,46 +28,46 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "Aufruf: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
 "Dateideskriptor, der auf die Konsole verweist, konnte nicht gefunden werden"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: Unbekannte Option\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: Ungültige VT-Nummer.\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 ist die Konsole und kann deshalb nicht freigegeben werden\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "Konsole %d konnte nicht freigegeben werden.: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys Version %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -104,7 +104,7 @@ msgstr ""
 "\t-d --compose-only   zeigt nur die Tastenfolgen an\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -113,7 +113,7 @@ msgstr ""
 "\t\t\t    interpretiert Zeichencodes, als kämen sie aus dem\n"
 "\t\t\t    angegebenen Zeichensatz.\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -122,17 +122,17 @@ msgstr ""
 "\t-v --verbose\n"
 "\t-V --version\t    zeigt die Versionsnummer an\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "Unbekannter Zeichensatz %s - Zeichensatzanforderung wird ignoriert.\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: Fehler beim Lesen des Tastaturmodus: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -143,7 +143,7 @@ msgstr ""
 "(Numerischer Wert, Symbol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -166,45 +166,33 @@ msgstr ""
 "\t-V --version         zeigt die Programmversion an\n"
 "\t-n --next-available  zeigt die Nummer des nächsten unbenutzten VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "VT-Nummer konnte nicht gelesen werden: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "%s kann nicht geöffnet werden.\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr ""
-"Dateideskriptor, der auf die Konsole verweist, konnte nicht gefunden "
-"werden.\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "Aufruf: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Einfache Scancodes xx (hexadezimal) und Tastencodes (dezimal):\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 ist ein Fehler; für 1-88 (0x01-0x58) ist Scancode gleich Tastencode\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 "0 ist ein Fehler; für 1-%d (0x01-0x%02x) ist Scancode gleich Tastencode\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -215,14 +203,14 @@ msgstr ""
 "\n"
 "Scancodes mit Escape e0 xx (hex):\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "Tastencode für den Scancode 0x%x kann nicht erhalten werden.: ioctl "
 "KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -259,72 +247,72 @@ msgstr "Fehler: Nicht genügend Argumente.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Fehler: Unbekannte Aktion: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "Aufruf: kbd_mode [-a|-u|-k|-s] [-C Gerät]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Die Tastatur ist im Urmodus (scancode).\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Die Tastatur ist im Tastencode-Modus (mediumraw).\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Die Tastatur ist im voreingestellten Modus (ASCII).\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Die Tastatur ist im Unicode-Modus (UTF-8).\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Der Tastaturmodus ist unbekannt.\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr ""
 "Die Wiederholrate ist auf %.1f Zeichen/s gesetzt (Verzögerung = %d ms).\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Aufruf: kbdrate [-V | --version] [-s] [-r Wert] [-d Verzögerung]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "/dev/port kann nicht geöffnet werden."
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "Fehler: getfont wurde mit einer Anzahl < 256 aufgerufen.\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "Fehler: Bei Verwendung von GIO_FONT braucht getfont einen Puffer.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: Arbeitsspeicher erschöpft.\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "Seltsam... ct hat sich von %d auf %d geändert\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -333,21 +321,38 @@ msgstr ""
 "Der Kernel scheint älter als 1.1.92 zu sein.\n"
 "Es wurde keine Unicode-Tabelle geladen.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "%s kann nicht geöffnet werden.\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr ""
+"Dateideskriptor, der auf die Konsole verweist, konnte nicht gefunden "
+"werden.\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s von %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "Arbeitsspeicher erschöpft"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "Feld konnte nicht initialisiert werden: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Fehler beim Schreiben der Tabelle in die Datei."
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "unmöglich: Keine Meta?\n"
@@ -367,72 +372,72 @@ msgstr "KDGKBSENT: %s: Funktionstasten-String konnte nicht erhalten werden"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: Akzenttabelle konnte nicht erhalten werden"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "Keymap %d konnte nicht erhalten werden"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "Taste %d konnte nicht aus Tabelle %d gelöst werden"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key mit ungültigem Tastencode %d aufgerufen"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "Hinzufügen von Map %d verletzt explizite keymaps-Zeile."
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "Taste %d konnte nicht für Tabelle %d gesetzt werden"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "Unmöglicher Fehler in lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "Symbol konnte durch falschen Typ nicht erhalten werden: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 "Symbol des Typs %d konnte durch falschen Index nicht erhalten werden: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "ISO-8859-1 %s wird angenommen"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "ISO-8859-15 %s wird angenommen"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "ISO-8859-2 %s wird angenommen"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "ISO-8859-3 %s wird angenommen"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "ISO-8859-4 %s wird angenommen"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "Unbekanntes Tastensymbol „%s“.\n"
@@ -483,12 +488,12 @@ msgstr ""
 "KDSKBMODE: %s: Ursprünglicher Tastaturmodus konnte nicht wiederhergestellt "
 "werden"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "String „%s“ konnte nicht der Funktion %s zugeordnet werden."
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "Das Leeren des Strings %s ist fehlgeschlagen."
@@ -497,7 +502,7 @@ msgstr "Das Leeren des Strings %s ist fehlgeschlagen."
 msgid "too many compose definitions"
 msgstr "Zu viele Compose-Definitionen"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -512,21 +517,21 @@ msgstr[1] ""
 "\n"
 "%d Tasten wurden geändert."
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] "%d Zeichenkette wurde geändert."
 msgstr[1] "%d Zeichenketten wurden geändert."
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "%d Compose-Definition wurde geladen."
 msgstr[1] "%d Compose-Definitionen wurden geladen."
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Compose-Definitionen nicht geändert.)"
 
@@ -595,7 +600,7 @@ msgstr ""
 "\n"
 "Erkannte Wandlernamen und ihre Spaltennummern:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -641,18 +646,13 @@ msgstr ""
 "  -v --verbose       berichtet ausführlicher über vorgenommene Änderungen\n"
 "  -V --version       zeigt die Versionsnummer an\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s von %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 "%s: Die Optionen --unicode und --ascii schließen sich gegenseitig aus\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -661,7 +661,7 @@ msgstr ""
 "%s: Warnung: Nicht-Unicode-Tastaturbelegung wird auf Unicode-Konsole\n"
 "    geladen (vielleicht möchten Sie zuvor „kbd_mode -a“ ausführen?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -670,17 +670,17 @@ msgstr ""
 "%s: Warnung: Unicode-Tastaturbelegung wird auf Nicht-Unicode-Konsole\n"
 "    geladen (vielleicht möchten Sie zuvor „kbd_mode -u“ ausführen?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "%s kann nicht gefunden werden.\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "Datei %s kann nicht geöffnet werden.\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -689,27 +689,27 @@ msgstr ""
 "Aufruf:\n"
 "%s [-C Konsole] [-o Originaltabelle]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Ungültige Eingabezeile: %s.\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Glyphennummer (0x%x) größer als Font-Länge.\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Ungültiges Bereichsende (0x%x).\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr "%s: Ungültiger Unicode-Bereich zum Font-Bereich 0x%x-0x%x.\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -718,22 +718,22 @@ msgstr ""
 "%s: Der Unicode-Bereich U+%x-U+%x ist nicht gleich lang wie der Font-Bereich "
 "0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: Überflüssiger Müll (%s) wurde ignoriert.\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Unicode-Tabelle wird aus der Datei %s geladen.\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Warnung: Die Zeile ist zu lang.\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -742,85 +742,85 @@ msgstr ""
 "%s: Eine leere Unicode-Tabelle wird nicht geladen.\n"
 "Benutzen Sie die Option -f zum Erzwingen der Aktion.\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "Eintrag"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "Einträge"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Unicode-Tabelle in „%s“ gespeichert.\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Unicode-Tabelle angehängt.\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "Aufruf: %s [-V] [-v] [-o Originaltabelle] Tabellendatei\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: Zuordnungsdatei _%s_ kann nicht geöffnet werden.\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Zuordnungsdatei kann nicht geöffnet werden."
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Binärer Font wird aus der Datei %s geladen.\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Fehler beim Lesen der Tabelle aus der Datei „%s“.\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Binäre Unicode-Tabelle wird aus der Datei %s geladen.\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Symboltabelle wird aus %s geladen.\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Fehler beim Verarbeiten der Symboltabelle „%s“, Zeile %d.\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Fehler beim Schreiben der Tabelle in die Datei.\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Konsolentabelle kann nicht gelesen werden.\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Bildschirmtabelle in „%s“ gespeichert.\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -853,11 +853,11 @@ msgstr ""
 "  -h, --help          zeigt diesen Hilfetext an.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Eigentümer des aktuellen Terminals konnte nicht gefunden werden!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: Ungültige VT-Nummer"
@@ -904,96 +904,96 @@ msgstr "VT %s wird benutzt"
 msgid "Cannot open %s read/write"
 msgstr "%s kann nicht zum Schreiben und Lesen geöffnet werden"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "VT %d kann nicht aktiviert werden"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Aktivierungsvorgang unterbrochen?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Konsole %d konnte nicht freigegeben werden"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: Kurze UCS2-Unicode-Tabelle.\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: Kurze UTF8-Unicode-Tabelle.\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: Falsches UTF-8.\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: Unbekannter UTF-8-Fehler.\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: Kurze Unicode-Tabelle.\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Fehler beim Lesen des Fonts."
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Falscher Aufruf von readpsffont.\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Nicht unterstützer PSF-Dateimodus (%d).\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Nicht unterstützte PSF-Version (%d).\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: Leerer Font?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: Ist die Zeichengröße Null?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Eingabedatei: Falsche Länge (%d).\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Eingabedatei: Angehänger Zeichenmüll.\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: Ungültiges Unicode-Zeichen %u.\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Kopf der Font-Datei kann nicht geschrieben werden."
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Font-Datei kann nicht geschrieben werden."
@@ -1079,31 +1079,41 @@ msgstr "%s: PSF-Datei mit unbekannter magischer Zeichenkette.\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: Der Font hat keinen Index.\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: Videomodus-Datei %s kann nicht gefunden werden.\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: Videomodus-Datei %s kann nicht gefunden werden.\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Ungültige Zeilenanzahl.\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Alter Modus: %dx%d  Neuer Modus: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Zeilenzahl alt: %d  Zeilenzahl neu: %d  Zeichenhöhe: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: Der Befehl „%s“ ist fehlgeschlagen.\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1111,7 +1121,7 @@ msgstr ""
 "resizecons: Vergessen Sie nicht, TERM zu ändern (z.B. zu con%dx%d oder linux-"
 "%dx%d).\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1125,42 +1135,42 @@ msgstr ""
 "oder:        resizecons -lines ZEILEN,\n"
 "                 mit ZEILEN in 25, 28, 30, 34, 36, 40, 44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: Ein-/Ausgabe-Erlaubnis kann nicht erhalten werden.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "Aufruf: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Fehler beim Lesen von %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr ""
 "%s kann nicht gelesen und ioctl auf den Bildschirminhalt angewendet werden.\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "%s kann nicht gelesen werden.\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Seltsam ... der Bildschirm ist sowohl %dx%d als auch %dx%d?\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Fehler beim Schreiben des Bildschirminhalts.\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1215,12 +1225,12 @@ msgstr ""
 "    -V         Ausgabe der Versionsnummer und Beenden.\n"
 "Dateien werden im aktuellen Verzeichnis oder in %s/*/ gesucht.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: Zu viele Eingabedateien.\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1229,125 +1239,125 @@ msgstr ""
 "setfont: Font kann nicht zugleich von ROM und Datei wiederhergestellt "
 "werden. Vorgang abgebrochen.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Falsche Zeichenhöhe %d.\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Falsche Zeichenbreite %d.\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: Stelle 32 im Font ist kein Leerzeichen.\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: wurde gelöscht.\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: Der Hintergrund wird seltsam aussehen.\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "%d-Zeichen %dx%d wird aus der Datei %s geladen.\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "%d-Zeichen %dx%d wird geladen.\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "%d-Zeichen %dx%d (%d) wird aus Datei %s geladen.\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "%d-Zeichen %dx%d (%d) wird geladen.\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: Fehler in do_loadtable.\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Unicode-Tabelle wird geladen …\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Font-Datei %s kann nicht geöffnet werden.\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Gleichzeitig geladene Fonts müssen im PSF-Format sein - %s ist es nicht.\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "%d-Zeichen %dx%d wird aus der Datei %s gelesen.\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 "Wenn mehrere Fonts geladen werden, müssen sie die gleiche Höhe haben.\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Wenn mehrere Fonts geladen werden, müssen alle die gleiche Breite haben.\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Standard-Font kann nicht gefunden werden.\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Font %s kann nicht gefunden werden.\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Font-Datei %s wird gelesen.\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Kein abschließender Zeilenumbruch in zusammengefügter Datei.\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Zu viele Dateien zum Zusammenfassen.\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - ein Font von restorefont? Die erste Hälfte wird verwendet.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Falsche Eingabedateigröße.\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1356,24 +1366,24 @@ msgstr ""
 "Diese Datei enthält 3 Fonts: 8x8, 8x14 und 8x16. Wählen Sie bitte\n"
 "mit einer Option aus -8, -14 oder -16 den zu ladenden Font aus.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Die Zeichengröße %d wurde verlangt, es sind aber nur 8, 14 und 16 "
 "verfügbar.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Nichts zum Speichern gefunden.\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "%d-Zeichen %dx%d in Font-Datei %s gespeichert.\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1384,19 +1394,19 @@ msgstr ""
 " (Wobei Scancode entweder xx oder e0xx hexadezimal\n"
 "  und der Tastencode dezimal angegeben wird.)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "Eine gerade Anzahl von Argumenten wird erwartet."
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "Fehler beim Lesen des Scancodes."
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "Scancode außerhalb der Grenzen."
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1576,12 +1586,12 @@ msgstr "Alter Status:    "
 msgid "new state:    "
 msgstr "Neuer Status:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "Aufruf: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1616,41 +1626,41 @@ msgstr ""
 "   -V     zeigt die Versionsnummer an\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Fehler: %s: Ungültiger Wert im Feld %u in Zeile %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Fehler: %s: Nicht genügend Felder in Zeile %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Fehler: %s: Zeile %u endet unerwartet.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Fehler: %s: Die Zeile %u ist zu lang.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr ""
 "Das Wiederherstellen der ursprünglichen Übersetzungstabelle ist "
 "fehlgeschlagen.\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "Das Wiederherstellen der ursprünglichen Unimap ist fehlgeschlagen.\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "Die Übersetzungstabelle konnte nicht gewechselt werden.\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1700,16 +1710,16 @@ msgstr ""
 "Font mit %d Zeichen wird angezeigt.\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?UNBEKANNT?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "KB-Modus war %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1718,12 +1728,12 @@ msgstr ""
 "[ Wenn Sie das unter X probieren, muss es nicht funktionieren, \n"
 "  da der X Server ebenfalls von /dev/console liest. ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "Signal %d erhalten, wird aufgeräumt …\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1780,11 +1790,11 @@ msgstr "gedrückt"
 msgid "keycode %3d %s\n"
 msgstr "Tastencode %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "Aufruf: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1794,17 +1804,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Die gesamte Anzeige der Konsole ist nun durch %s gesperrt.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "Die %s ist nun durch %s gesperrt.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 "Verwenden Sie Alt+Funktionstasten, um auf andere virtuelle Konsolen zu "
@@ -1815,7 +1825,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr "Versuchen Sie „%s --help“ für mehr Informationen.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1842,16 +1852,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "Benutzer nicht erkannt"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "Standardeingabe ist keine tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Diese tty (%s) ist keine virtuelle Konsole.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Die gesamte Konsolenanzeige konnte nicht gesperrt werden.\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd-2.0.3-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2015-08-30 02:12+0300\n"
 "Last-Translator: Lefteris Dimitroulakis <ledimitro@gmail.com>\n"
 "Language-Team: Greek <team@lists.gnome.gr>\n"
@@ -19,45 +19,45 @@ msgstr ""
 "X-Generator: Lokalize 1.5\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "χρήση: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Δέν μπορώ να λάβω περιγραφέα αρχείου πού αφορά την κονσόλα"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: άγνωστη επιλογή\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: παράτυπος αριθμός VT\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 είναι η κονσόλα και δεν μπορεί ν' αποδεσμευτεί\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "αδυναμία αποδέσμευσης της κονσόλας %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys έκδοση %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -96,7 +96,7 @@ msgstr ""
 "\t   --compose-only    εμφάνιση μόνο των συνδιασμών compose των πλήκτρων\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -105,24 +105,24 @@ msgstr ""
 "\t\t\t    διερμηνεία κωδικών των χαρακτήρων ενέργειας\n"
 "\t\t\t    από το προδιαγεγραμμένο σύνολο χαρακτήρων\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "άγνωστο σύνολο χαρακτήρων %s - η αίτηση αγνοήθηκε\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: σφάλμα ανάγνωσης keyboard mode: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -133,7 +133,7 @@ msgstr ""
 "(αριθμητική τιμή, σύμβολο)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -156,45 +156,35 @@ msgstr ""
 "\t-V --version         εμφάνιση έκδοσης προγράμματος\n"
 "\t-n --next-available  εμφάνιση αριθμού του επόμενου μη δεσμευμένου VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Δεν μπόρεσα να διαβάσω VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Αδυνατώ ν' ανοίξω το %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Δέν μπορώ να λάβω περιγραφέα αρχείου πού αφορά την κονσόλα\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "χρήση: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr ""
 "Απλοί κωδικοί σάρωσης xx (hex) και οι αντίστοιχοι κωδικοί πλήκτρων (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 είναι ένα σφάλμα, γιά 1-88 (0x01-0x58) ο κωδικός σάρωσης ισούται με τον "
 "κωδικό πλήκτρου\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 "για 1-%d (0x01-0x%02x) ο κωδικός σάρωσης ισούται με τον κωδικό πλήκτρου\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -205,14 +195,14 @@ msgstr ""
 "\n"
 "Κωδικοί σάρωσης διαφυγής e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "αποτυχία κατά τη λήψη κωδικού πλήκτρου  γιά τον κώδικα σάρωσης 0x%x: ioctl "
 "KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -246,71 +236,71 @@ msgstr "Σφάλμα: Όχι αρκετά ορίσματα.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Σφάλμα: Άγνωστη ενέργεια: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "χρήση: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται σε ακατέργαστη (scancode) κατάσταση\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Το πληκτρολόγιο είναι σε ημικατεργασμένη (keycode) κατάσταση\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται στην προεπιλεγμένη κατάσταση (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται σε κατάσταση Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται σε κάποια άγνωστη κατάσταση\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Ο ρυθμός επανάληψης ρυθμίστηκε σε %.1f cps (καθυστέρηση = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Χρήσις: kbdrate [-V] [-s] [-r ρυθμός] [-d καθυστέρηση]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Αδυνατώ ν' ανοίξω το /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "bug: getfont κλήθηκε με μετρητή<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "bug: getfont using GIO_FONT needs buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: εξάντληση μνήμης\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "περίεργο... ct άλλαξε από %d σε %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -319,21 +309,36 @@ msgstr ""
 "Φαίνεται πως ο πυρήνας είναι παλαιότερος του 1.1.92\n"
 "Δεν φορτώθηκε πίνακας Unicode.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Αδυνατώ ν' ανοίξω το %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Δέν μπορώ να λάβω περιγραφέα αρχείου πού αφορά την κονσόλα\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s από %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "εξάντληση μνήμης"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "unable to initialize array: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Σφάλμα εγγραφής του πίνακα απεικόνισης στο αρχείο"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "αδύνατον: δεν είναι meta;\n"
@@ -353,71 +358,71 @@ msgstr "KDGKBSENT: %s: Unable to get function key string"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: Δεν μπορώ να βρω τον πίνακα των τόνων"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "unable to get keymap %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "unable to unset key %d for table %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "η lk_add_key κλήθηκε με λάθος κωδικό πλήκτρου %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "η προσθήκη map %d παραβιάζει υπάρχουσα σαφή αντιστοίχιση πλήκτρων"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "αποτυχία απόδωσης στο πλήκτρο %d της τιμής %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "αδύνατο σφάλμα σε lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "unable to get symbol by wrong type: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "unable to get symbol of %d type by wrong index: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "υποθέτοντας iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "υποθέτοντας iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "υποθέτοντας iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "υποθέτοντας iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "υποθέτοντας iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "άγνωστο keysym «%s»\n"
@@ -466,12 +471,12 @@ msgstr "KDSKBENT: %s: αδυναμία αποδέσμευσης ή καθαρι�
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: αποτυχία επιστροφής στην αρχική keyboard mode"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "αποτυχία σύνδεσης συμβολοσειράς «%s» με τη συνάρτηση %s"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "αποτυχία καθαρισμού συμβολοσειράς %s"
@@ -480,7 +485,7 @@ msgstr "αποτυχία καθαρισμού συμβολοσειράς %s"
 msgid "too many compose definitions"
 msgstr "πάρα πολλοί ορισμοί compose"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -495,21 +500,21 @@ msgstr[1] ""
 "\n"
 "Changed %d keys"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] "Αλλαγή του %d"
 msgstr[1] "Changed %d strings"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "Loaded %d compose definition"
 msgstr[1] "Loaded %d compose definitions"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Ουδεμία αλλαγή στους ορισμούς compose.)"
 
@@ -579,7 +584,7 @@ msgstr ""
 "\n"
 "Ονόματα αναγνωρισμένων μετατροπέων και οι αριθμοί τους στήλης :\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, fuzzy, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -623,17 +628,12 @@ msgstr ""
 "  -u --unicode       υποχρεωτική μετατροπή σε Unicode\n"
 "  -v --verbose       αναφορά των αλλαγών\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s από %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: Οι επιλογές --unicode and --ascii είναι αμοιβέα αποκλειόμενες\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -642,7 +642,7 @@ msgstr ""
 "%s: προειδοποίηση: φόρτωση μη-Unicode keymap σε κονσόλα Unicode\n"
 "    (μήπως θες να δώσεις «kbd_mode -a»;)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -651,17 +651,17 @@ msgstr ""
 "%s: προειδοποίηση: φόρτωση Unicode keymap σε μη-Unicode κονσόλα\n"
 "    (μήπως θέλεις να δώσεις `kbd_mode -u';)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Αδυναμία εύρεσης %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "Αδυνατώ ν' ανοίξω το αρχείο %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -670,30 +670,30 @@ msgstr ""
 "Χρήση:\n"
 "\t%s [-C console] [-o map.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Εσφαλμένη γραμμή εισόδου: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr ""
 "%s: Αριθμός γλύφου (0x%x) μεγαλύτερος απ' το μήκος της γραμματοσειράς\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Εσφαλμένο πέρας περιοχής (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Εσφαλμένη περιοχή Unicode πού αντιστοιχεί στη περιοχή θέσεων 0x%x-0x%x "
 "της γραμματοσειράς.\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -702,22 +702,22 @@ msgstr ""
 "%s: περιοχή Unicode U+%x-U+%x όχι του ιδίου μήκους με την περιοχή θέσεων 0x "
 "%x-0x%x της γραμματοσειράς\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: σκουπίδια στο τέλος (%s) αγνοήθηκαν\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Φόρτωση της απεικόνισης unicode από το αρχείο %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Προειδοποίηση: γραμμή πολύ μεγάλη\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -726,89 +726,89 @@ msgstr ""
 "%s: δεν φορτώνεται άδεια unimap\n"
 "(άν επιμένετε: χρησιμοποιείστε την επιλογή -f γιά παράβλεψη)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "καταχώρηση"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "καταχωρήσεις"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Ο πίνακας απεικόνισης unicode διασώθηκε στο «%s»\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Προστέθηκε πίνακας απεικόνισης Unicode \n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "χρήση: %s [-v] [-o map.orig] map-αρχείο\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: αδυνατώ ν' ανοίξω το αρχείο απεικόνισης _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Cannot stat map file"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr ""
 "Φόρτωση δυαδικής απεικόνισης της οθόνης απευθείας-στη-γραμματοσειρά από το "
 "αρχείο %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Σφάλμα κατά την ανάγνωση του πίνακα απεικόνισης από το αρχείο «%s»\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Φόρτωση της δυαδικής απεικόνισης unicode της οθόνης από το αρχείο %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Φόρτωση του πίνακα απεικόνισης συμβόλων της οθόνης από το αρχείο %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr ""
 "Σφάλμα κατά τη γραμματοσυντακτική ανάλυση του πίνακα απεικόνισης συμβόλων "
 "από «%s», γραμμή %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Σφάλμα εγγραφής του πίνακα απεικόνισης στο αρχείο\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Αδυναμία ανάγνωσης του πίνακα απεικόνισης της κονσόλας\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Ο πίνακας απεικόνισης της οθόνης διασώθηκε στο «%s»\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -840,11 +840,11 @@ msgstr ""
 "  -h, --help          output a brief help message.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Δεν μπόρεσα να βρω τον ιδιοκτήτη του τρέχοντος tty!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: παράτυπος αριθμός vt"
@@ -891,96 +891,96 @@ msgstr "χρησιμοποίηση VT %s"
 msgid "Cannot open %s read/write"
 msgstr "Δεν μπορώ ν' ανοίξω το %s σε ανάγνωση/εγγραφή"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "αδυναμία ενεργοποίησης vt %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "η ενεργοποίηση διακόπηκε;"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "αδυναμία αποδέσμευσης της κονσόλας %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: λειψός πίνακας unicode usc2\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: λειψός πίνακας utf8 unicode\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: εσφαλμένος utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: άγνωστο σφάλμα utf8\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: λειψός πίνακας unicode\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Σφάλμα κατά την ανάγνωση της γραμματοσειράς εισόδου"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Εσφαλμένη κλήση της readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Μη υποστηριζόμενη κατάσταση αρχείου psf (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Μή υποστηριζόμενη έκδοση psf (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: μήκος γραμματοσειράς εισόδου μηδέν;\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: μέγεθος χαρακτήρα εισόδου μηδέν;\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Αρχείο εισόδου: εσφαλμένο μήκος εισόδου (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Αρχείο εισόδου: σκουπίδια στο τέλος\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: παράτυπος κωδικός unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Αδυνατώ να γράψω την επικεφαλίδα του αρχείου γραμματοσειράς"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Δεν μπορώ να γράψω στο αρχείο της γραμματοσειράς"
@@ -1065,38 +1065,48 @@ msgstr "%s: αρχείο psf με άγνωστο μαγικό αριθμό\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: η γραμματοσειρά εισόδου δεν περιέχει ευρετήριο\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: αδυνατώ να βρώ το αρχείο videomode %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: αδυνατώ να βρώ το αρχείο videomode %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Ακυρος αριθμός γραμμών\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Παλαιά κατάσταση: %dx%d  Νέα κατάσταση: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Παλαιές #scanlines: %d  Νέες #scanlines: %d  Υψος χαρακτήρα: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: η διαταγή «%s» αστόχησε\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: μή ξεχνάτε την αλλαγή του TERM (ίσως σε con%dx%d ή linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1109,42 +1119,42 @@ msgstr ""
 "ή: resizecons -lines ROWS, με ROWS μία από 25, 28, 30, 34, 36, 40, 44, 50, "
 "60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: αδυνατώ να λάβω άδειες I/O.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "χρήση: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Σφάλμα ανάγνωσης %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr ""
 "αδυναμία ανάγνωσης του %s, και δεν μπορώ να το εμφανίσω με την ioctl()\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "αδύνατη ανάγνωση %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Περίεργο ...η οθόνη είναι συγχρόνως %dx%d και %dx%d ;;\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Σφάλμα εγγραφής screendump\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1201,12 +1211,12 @@ msgstr ""
 "    -V           Εμφάνιση πληροφοριών έκδοσης κι έξοδος.\n"
 "Τα αρχεία φορτώνονται από τον τρέχοντα κατάλογο ή από %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: πάρα πολλά αρχεία εισόδου\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1215,126 +1225,126 @@ msgstr ""
 "setfont: αδύνατη επαναφορά από τη ROM χαρακτήρων και απο αρχείο συγχρόνως.Η "
 "γραμματοσειρά παραμένει αμετάβλητη.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Εσφαλμένο ύψος χαρακτήρα %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Εσφαλμένο πλάτος χαρακτήρα %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: η θέση 32 της γραμματοσειράς δεν είναι κενή\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: το καθάρισα\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: το υπόβαθρο θα φαίνεται αλλόκοτο\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d απο το αρχείο %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d (%d) απο το αρχείο %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: bug στο do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Φόρτωση πίνακα απεικόνισης Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Αδυνατώ ν' ανοίξω το αρχείο γραμματοσειράς %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Κατά τη φόρτωση διαφόρων γραμμ/σειρών, όλες πρέπει να είναι psf - %s δεν "
 "είναι\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Ανάγνωση %d-χαρακτ. της γραμματοσειράς %dx%d από το αρχείο %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 "Κατά τη φόρτωση πολλών γραμματοσειρών, όλες πρέπει να έχουν το ίδιο ύψος\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Κατά τη φόρτωση πολλών γραμματοσειρών, όλες πρέπει να έχουν ίδιο πλάτος\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Αδυνατώ να βρώ την προεπιλεγμένη γραμματοσειρά\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Αδυνατώ να βρώ τη γραμματοσειρά %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Ανάγνωση αρχείου γραμματοσειράς %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Δεν υπάρχει τελική γραμμή στο συνδιασμένο αρχείο\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Πάρα πολλά αρχεία γιά συνδιασμό\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Χμμ - γραμματοσειρά απο το restorefont; Χρήση του πρώτου μισού.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Εσφαλμένο μέγεθος αρχείου εισόδου\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1343,23 +1353,23 @@ msgstr ""
 "Αυτό το αρχείο περιέχει 3 γραμματοσειρές: 8x8, 8x14 και 8x16. Παρακαλώ\n"
 "υποδείξτε με τις επιλογές -8 ή -14 ή -16 ποιά θέλετε.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Ζητήσατε μέγεθος γραμματοσειράς %d, αλλά μόνον 8, 14, 16 είναι δυνατόν εδώ.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Τίποτε γιά διάσωση\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "%d-χαρακτ. της γραμματοσειράς %dx%d διασώθηκαν στο αρχείο %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1370,19 +1380,19 @@ msgstr ""
 " (όπου ο scancode είναι xx ή e0xx, σε δεκαεξαδική μορφή,\n"
 "  και ο keycode σε δεκαδική)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "αναμενόταν ζυγός αριθμός ορισμάτων "
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "σφάλμα ανάγνωσης κωδικού σάρωσης"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "κωδικός εκτός ορίων"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1566,12 +1576,12 @@ msgstr "παλαιά κατάσταση:        "
 msgid "new state:    "
 msgstr "νέα κατάσταση:       "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "χρήση: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1601,39 +1611,39 @@ msgstr ""
 "and then edit the values in FILE.\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Σφάλμα: %s: Άκυρη τιμή στο πεδίο %u στη γραμμή %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Σφάλμα: %s: Ανεπαρκής αριθμός πεδίων στη γραμμή %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Σφαλμα: %s: Η γραμμη %u περατωθηκε αναπαντεχα.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Σφάλμα: %s: Γραμμή %u είναι πολύ μεγάλη.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "αποτυχία αποκατάστασης αρχικού πίνακα μετάφρασης\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "αποτυχία αποκατάστασης αρχικού unimap\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "αδυνατώ ν' αλλάξω τον πίνακα μετάφρασης\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1682,16 +1692,16 @@ msgstr ""
 "Εμφάνιση γραμματοσειράς %d-χαρακτήρων\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr ";ΑΓΝΩΣΤΗ;"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "Η κατάσταση kb ήταν %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1700,12 +1710,12 @@ msgstr ""
 "[ αν το προσπαθείτε στα Χ, ίσως να μη δουλεύει\n"
 "αφού κι ο εξυπηρετητής Χ διαβάζει επίσης το /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "ελήφθη το σήμα %d, καθαρισμός...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1763,11 +1773,11 @@ msgstr "πάτημα"
 msgid "keycode %3d %s\n"
 msgstr "κωδικός πλήκτρου %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "χρήση: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1777,17 +1787,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Ολόκληρη η κονσόλα είναι τώρα τελείως κλειδωμένη από %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "%s κλειδώθηκε από %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr "Χρησιμοποίησε Alt-Fn για μετάβαση σε άλλες εικονικές κονσόλες."
 
@@ -1796,7 +1806,7 @@ msgstr "Χρησιμοποίησε Alt-Fn για μετάβαση σε άλλε�
 msgid "Try `%s --help' for more information.\n"
 msgstr "Δοκίμασε «%s --help» για περισσότερες πληροφορίες.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1825,16 +1835,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "ο χρήστης δεν αναγνωρίζεται"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "stdin δεν είναι tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Αυτό το tty (%s) δεν είναι εικονική κονσόλα.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Ολόκληρη η κονσόλα δεν μπορεί να κλειδωθεί.\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.3-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-03-04 11:20-0300\n"
 "Last-Translator: Felipe Castro <fefcas@gmail.com>\n"
 "Language-Team: Esperanto <translation-team-eo@lists.sourceforge.net>\n"
@@ -20,45 +20,45 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "uzmaniero: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Ne eblis preni dosier-priskribilon rilatanta al la konzolo"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: nekonata modifilo\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: malpermesata VT-numero\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 estas la konzolo kaj ne povas esti liberigata\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "ne eblis liberigi la konzolon %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys versio %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -95,7 +95,7 @@ msgstr ""
 "\t   --compose-only   montri nur kunmetajn klav-kombinojn\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -104,24 +104,24 @@ msgstr ""
 "\t\t\t    interpreti signajn ago-kodojn kvazaŭ ili estu el la\n"
 "\t\t\t    specifita signaro\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "nekonata signaro %s - ni preteratentas peton de signaro\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: eraro dum legado de la klavar-reĝimo: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -132,7 +132,7 @@ msgstr ""
 "(cifera valoro, simbolo)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -155,41 +155,31 @@ msgstr ""
 "\t-V --version         montri la programo-version\n"
 "\t-n --next-available  montri kiom da venontaj nerezervitaj VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Ne eblis legi VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Ne eblis malfermi %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Ne eblis preni dosier-priskriblon rilatanta al la konzolo\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "uzmaniero: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Simplaj skankodoj xx (16-ume) kontraŭ klavkodoj (10-ume)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr "0 estas eraro; inter 1-88 (0x01-0x58) skankodoj egalas al klavkodoj\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "inter 1-%d (0x01-0x%02x) skankodoj egalas al klavkodoj\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -200,12 +190,12 @@ msgstr ""
 "\n"
 "Ni preterpasis skankodojn e0 xx (16-ume)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "malsukcesis preni klavkodon por skankodo 0x%x: ioctl KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -239,71 +229,71 @@ msgstr "Eraro: Ne sufiĉe da argumentoj.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Eraro: Nerekonita ago: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "uzmaniero: kbd_mode [-a|-u|-k|-s] [-C aparato]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "La klavaro estas en kruda (skankoda) reĝimo\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "La klavaro estas en mezkruda (klavkoda) reĝimo\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "La klavaro estas en la apriora (ASCII) reĝimo\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "La klavaro estas en Unikoda (UTF-8) reĝimo\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "La klavaro estas en iu nekonata reĝimo\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Ripet-Rapido fiksita po %.1f signoj sekunde (prokrasto = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Uzmaniero: kbdrate [-V] [-s] [-r rapido] [-d prokrasto]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Ni ne povas malfermi /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "miso: getfont vokita kun count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "miso: getfont uzanta GIO_FONT postulas bufron.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: mankas memoro\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "strange... ct ŝanĝis el %d al %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -312,21 +302,36 @@ msgstr ""
 "Ŝajnas ke tiu ĉi kerno estas pli malnova ol 1.1.92\n"
 "Neniu Unikoda map-tabelo ŝargita.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Ne eblis malfermi %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Ne eblis preni dosier-priskriblon rilatanta al la konzolo\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s el %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "mankas memoro"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "ne eblas ekplenigi matricon: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Eraro dum skribo de mapo al dosiero"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "neeble: ne estas meta?\n"
@@ -346,71 +351,71 @@ msgstr "KDGKBSENT: %s: ne eblas preni ŝlosilan ĉenon de funkcio"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: ne eblas preni kromsignan tabelon"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "ne eblas preni klavmapon %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "ne eblas malŝalti klavon %d por tabelo %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key vokita kun malĝusta klavkodo %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "aldonado de la mapo %d malrespektas linion de keymaps"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "ne eblas ŝalti klavon %d por tabelo %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "malebla eraro en lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "ne eblas preni simbolon per malkorekta tipo: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "ne eblas preni simbolon de tipo %d per malkorekta indico: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "ni konsideras kiel iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "ni konsideras kiel iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "ni konsideras kiel iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "ni konsideras kiel iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "ni konsideras kiel iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "nekonata klavsimbolo '%s'\n"
@@ -459,12 +464,12 @@ msgstr "KDSKBENT: %s: ne eblas liberigi aŭ forviŝi klavmapon"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: ne eblis retroiri al la originala klavar-reĝimo"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "fiasko ligi ĉenon '%s' al funkcio %s"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "fiasko forviŝi ĉenon %s"
@@ -473,7 +478,7 @@ msgstr "fiasko forviŝi ĉenon %s"
 msgid "too many compose definitions"
 msgstr "tro da kunmetaj difinoj"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -488,21 +493,21 @@ msgstr[1] ""
 "\n"
 "Ni ŝanĝis %d ŝlosilojn"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] "Ni ŝanĝis %d ĉenon"
 msgstr[1] "Ni ŝanĝis %d ĉenojn"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "Ni ŝargis je %d kunmeta difino"
 msgstr[1] "Ni ŝargis je %d kunmetaj difinoj"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Neniu ŝanĝo en kunmetaj difinoj)"
 
@@ -571,7 +576,7 @@ msgstr ""
 "\n"
 "Rekoneblaj modif-nomoj kaj ties kolumno-numeroj:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, fuzzy, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -615,17 +620,12 @@ msgstr ""
 "  -u --unicode       devigi konvertadon al Unikodo\n"
 "  -v --verbose       listigi la ŝanĝojn\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s el %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: Elektoj --unicode kaj --ascii estas reciproke malkunigeblaj\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -634,7 +634,7 @@ msgstr ""
 "%s: averto: ŝargado je ne-Unikoda klavmapo ĉe Unikoda konzolo\n"
 "    (eble vi volas fari `kbd_mode -a'?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -643,17 +643,17 @@ msgstr ""
 "%s: averto: ŝargado je Unikoda klavmapo al ne-Unikoda konzolo\n"
 "    (eble vi volas fari `kbd_mode -u'?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Ni ne povas trovi %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "ne malfermeblas la dosiero %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -662,28 +662,28 @@ msgstr ""
 "Uzmaniero:\n"
 "\t%s [-C konzolo] [-o map.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Malĝusta enig-linio: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Signobilda numero (0x%x) pli granda ol longo de tiparo\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Malĝusta fino de rango (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Malĝusta Unikoda rango koresponda al pozicia rango de tiparo 0x%x-0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -692,22 +692,22 @@ msgstr ""
 "%s: Unikoda rango U+%x-U+%x ne longas same ol pozicia rango de fonto 0x%x-0x"
 "%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: vosta rubaĵo (%s) preteratentita\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Ŝargado je unikoda map el dosiero %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Averto: linio tro longa\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -716,85 +716,85 @@ msgstr ""
 "%s: ne ŝargadas malplenan unikodmapon\n"
 "(se vi insistas: uzu modifilon -f por preterpasi)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "enigo"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "enigoj"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Unikoda mapo konservita en '%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Postmetita Unikoda mapo\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "uzmaniero: %s [-v] [-o map.orig] map-dosiero\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: ne povas malfermi map-dosieron _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Ne eblas statlegi map-dosieron"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Ŝargado je duuma rekte-al-tipara ekran-mapo el dosiero %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Eraro dum legado de mapo el dosiero '%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Ŝargado je duuma unikoda ekran-mapo el dosiero %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Ŝargado je simbola ekran-mapo el dosiero %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Eraro dum analizado de simbola mapo el '%s', linio %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Eraro dum skribo de mapo al dosiero\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Ne eblas legi konzolan mapon\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Ekran-mapo konservita en '%s'\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -826,11 +826,11 @@ msgstr ""
 "  -h, --help          eligi mallongan help-mesaĝon.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Ne povis trovi la posedanton de la aktuala tty!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: Malpermesata numero de vt"
@@ -876,96 +876,96 @@ msgstr "Ni uzadas VT %s"
 msgid "Cannot open %s read/write"
 msgstr "Ne eblas malfermi %s lege/skribe"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Ne povis aktivigi vt %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Ĉu aktivigo interrompita?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Ne eblis liberigi la konzolon %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: mallonga unikoda tabelo ucs2\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: mallonga unikoda tabelo utf8\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: malĝusta utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: nekonata eraro utf8\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: mallonga unikoda tabelo\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Eraro dum legado de eniga tiparo"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Malĝusta voko al readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Nesubtenata dosiera reĝimo psf (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Nesubtenata versio psf (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: ĉu nula eniga tipar-longo?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: ĉu nula eniga signo-grando?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Enig-dosiero: malĝusta eniga longo (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Enig-dosiero: vosta rubaĵo\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: malpermesata unikodo %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Ne eblas skribi tiparan dosier-kapon"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Ne eblas skribi tipar-dosieron"
@@ -1048,37 +1048,47 @@ msgstr "%s: dosiero psf kun nekota magi-numero\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: eniga tiparo ne havas indicon\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: ne eblas trovi dosieron videomode %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: ne eblas trovi dosieron videomode %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Malvalida nombro da linioj\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Malnova reĝimo: %dx%d  Nova reĝimo: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Malnovaj #skanlinioj: %d  Novaj #skanlinioj: %d  Signo-alto: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: la komando '%s' malsukcesis\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr "resizecons: ne forgesu ŝanĝi TERM (eble al con%dx%d aŭ linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1091,41 +1101,41 @@ msgstr ""
 "aŭ: resizecons -lines LIN, kie LIN estu unu el 25, 28, 30, 34, 36, 40, 44, "
 "50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: ne eblas havi permesojn EN/EL.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "uzmaniero: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Eraro dum legado de %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "ne eblis legi %s, kaj ne eblas uzi ioctl dump\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "ne eblis legi %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Strange ... ekrano estas kaj %dx%d kaj %dx%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Eraro dum skribado de ekrankopio\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1180,12 +1190,12 @@ msgstr ""
 "    -V         Printi version kaj eliri.\n"
 "Dosieroj estas ŝargataj el la aktuala dosierujo aŭ el %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: tro da enig-dosieroj\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1194,122 +1204,122 @@ msgstr ""
 "setfont: ne eblas restarigi kaj el signeca ROM kaj el dosiero. Tiparo "
 "neŝanĝita.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Malĝusta signo-alto %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Malĝusta signo-larĝo %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: tipar-pozicio 32 estas nespaca\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: viŝis ĝin\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: fono ŝajnos ridinda\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Ŝargado je tiparo %d-char %dx%d el dosiero %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Ŝargado je tiparo %d-char %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Ŝargado je tiparo %d-char %dx%d (%d) el dosiero %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Ŝargado je tiparo %d-char %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: miso en do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Ŝargado je Unikoda mapiga tabelo...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Ne eblas malfermi la tipar-dosieron %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr "Dum ŝargado je pluraj tiparoj, ĉiuj devas esti psf - %s ne estas\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Legi tiparon %d-char %dx%d el dosiero %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Dum ŝargado je pluraj tiparoj, ĉiuj devas havi la saman alton\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "Dum ŝargado je pluraj tiparoj, ĉiuj devas havi la saman larĝon\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Ne eblas trovi aprioran tiparon\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Ne eblas trovi la tiparon %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Legado de tipar-dosiero %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Neniu fina novlinio en kunmeta dosiero\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Tro da dosieroj por kunmeti\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - ĉu tiparo el restorefont? Ni uzas la unuan duonon.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Malĝusta grando de enig-dosiero\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1318,22 +1328,22 @@ msgstr ""
 "Tiu ĉi dosiero enhavas 3 tiparojn: 8x8, 8x14 kaj 8x16. Bonvolu indiki\n"
 "uzante modifilon -8 aŭ -14 aŭ -16 je kiu el ili vi volas ŝargi.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr "Vi petis tipar-grandon %d, sed nur 8, 14 kaj 16 eblas ĉi tie.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Nenio trovita por konservi\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Konservita tipar-dosiero %d-char %dx%d en %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1344,19 +1354,19 @@ msgstr ""
 " (kie skankodo estas xx aŭ e0xx, indikata deksesume,\n"
 "  kaj klavkodo estas indikata dekume)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "para nombro da argumentoj atendataj"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "eraro dum legado de skankodo"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "kodo for de limoj"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "malsukcesis alĝustigi skankodon %x al klavkodo %d: ioctl KDSETKEYCODE"
@@ -1534,12 +1544,12 @@ msgstr "malnova stato: "
 msgid "new state:    "
 msgstr "nova stato: "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "uzmaniero: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1569,39 +1579,39 @@ msgstr ""
 "kaj tiam redaktu la valorojn en DOSIERO.\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Eraro: %s: Malvalida valoro en kampo %u en linio %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Eraro: %s: Ne sufiĉa nombro da kampoj en linio %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Eraro: %s: Linio %u finiĝis ne atendite.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Eraro: %s: Linio %u tro longas.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "malsukcesis restarigi originalan traduk-tabelon\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "malsukcesis restarigi originalan unimapon\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "ne eblas ŝanĝi traduk-tabelon\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1649,16 +1659,16 @@ msgstr ""
 "Montrado de tiparo %d-char\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?NEKONATA?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "kb-reĝimo estis %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1667,12 +1677,12 @@ msgstr ""
 "[ se vi provas tion ĉi sub X, ĝi eble ne funkcios\n"
 "ĉar la servilo X ankaŭ legas /dev/console, nune ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "kaptinte la signalon %d, ni forviŝadas...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1727,11 +1737,11 @@ msgstr "premite"
 msgid "keycode %3d %s\n"
 msgstr "klavkodo %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "uzmaniero: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1741,17 +1751,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "La tuta konzola montrilo estas nun entute ŝlosita de %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "La %s estas nun ŝlosita de %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr "Uzi Alt-funkciajn klavojn por alterni al aliaj virtualaj konsoloj."
 
@@ -1760,7 +1770,7 @@ msgstr "Uzi Alt-funkciajn klavojn por alterni al aliaj virtualaj konsoloj."
 msgid "Try `%s --help' for more information.\n"
 msgstr "Provu '%s --help' por pli da informoj.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1788,16 +1798,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "nerekonita uzanto"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "ĉef-enigo ne estas tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Tiu ĉi tty (%s) ne estas virtuala konzolo.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "La tuta konzola montrilo ne povas esti ŝlosita.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd-1.14.1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2008-05-14 23:48+0200\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -17,49 +17,49 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "uso: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 #, fuzzy
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
 "No se pudo conseguir un descriptor de fichero que refiera a la consola\n"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: opción desconocida\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s: 0: número de terminal virtual no válido\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s: la terminal virtual 1 es la consola y no puede liberarse\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s: no se pudo liberar la consola %d\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys, versión %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -96,7 +96,7 @@ msgstr ""
 "     --compose-only    mostrar sólo las combinaciones con la tecla Componer\n"
 "  -c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -105,24 +105,24 @@ msgstr ""
 "                       interpretar que los códigos de acción de carácter\n"
 "                       proceden del conjunto de caracteres especificado\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "conjunto de caracteres %s desconocido - no se atiende a la petición\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: error al establecer el modo de teclado\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -133,7 +133,7 @@ msgstr ""
 "(valor numérico, símbolo)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, fuzzy, c-format
 msgid ""
 "%s version %s\n"
@@ -157,45 +157,34 @@ msgstr ""
 "  -n --next-available  mostrar el número de la próxima terminal virtual "
 "libre\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "no se pudo leer VTNO: "
 
-#: src/getfd.c:69
-#, fuzzy, c-format
-msgid "Couldn't open %s\n"
-msgstr "No se pudo abrir %s\n"
-
-#: src/getfd.c:86
-#, fuzzy, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr ""
-"No se pudo conseguir un descriptor de fichero que refiera a la consola\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "uso: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Códigos de rastreo simples xx (hex) frente a códigos de tecla (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 es un error; para 1-88 (0x01-0x58) los códigos de rastreo son iguales que "
 "los de tecla\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 "para 1-%d (0x01-0x%02x) el código de rastreo es igual que el de tecla\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -206,12 +195,12 @@ msgstr ""
 "\n"
 "Códigos de rastreo con escape e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "fallo al averiguar el código de tecla para el código de rastreo 0x%x\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -241,96 +230,112 @@ msgstr ""
 "argumento desconocido: _%s_\n"
 "\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "uso: kbd_mode [-a|-u|-k|-s] [-C dispositivo]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "El teclado está en modo crudo (de código de rastreo)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "El teclado está en modo medio crudo (de código de tecla)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "El teclado está en el modo predeterminado (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "El teclado está en modo Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "El teclado está en algún modo desconocido\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr ""
 "Cadencia de repetición automática de tecla fijada a %.1f cps (retraso = %d "
 "ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Uso: kbdrate [-V] [-s] [-r cadencia] [-d retraso]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "No se puede abrir /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "error interno: llamada a getfont con contador<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "error interno: cuando getfont() usa GIO_FONT necesita un buffer.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: memoria agotada\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr ""
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
 "No Unicode mapping table loaded.\n"
 msgstr ""
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, fuzzy, c-format
+msgid "Couldn't open %s\n"
+msgstr "No se pudo abrir %s\n"
+
+#: src/libcommon/getfd.c:86
+#, fuzzy, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr ""
+"No se pudo conseguir un descriptor de fichero que refiera a la consola\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s de %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s: memoria agotada\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "Error al escribir la tabla asociativa en el fichero\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "imposible: ¿no será una tecla Meta?\n"
@@ -350,71 +355,71 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "fallo al averiguar el código de tecla para el código de rastreo 0x%x\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr ""
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr "fallo al averiguar el código de tecla para el código de rastreo 0x%x\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "conjeturando iso-8859-1 %s\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "conjeturando iso-8859-15 %s\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "conjeturando iso-8859-2 %s\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "conjeturando iso-8859-3 %s\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "conjeturando iso-8859-4 %s\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "keysym '%s' desconocida\n"
@@ -463,12 +468,12 @@ msgstr ""
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr ""
@@ -478,7 +483,7 @@ msgstr ""
 msgid "too many compose definitions"
 msgstr "número máximo de definiciones de composición:  %d\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -489,21 +494,21 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "número máximo de definiciones de composición:  %d\n"
 msgstr[1] "número máximo de definiciones de composición:  %d\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "número máximo de definiciones de composición:  %d\n"
@@ -573,7 +578,7 @@ msgstr ""
 "\n"
 "Nombres de modificador reconocidos y sus números de columna:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -598,71 +603,66 @@ msgid ""
 "  -V --version       print version number\n"
 msgstr ""
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s de %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
 "    (perhaps you want to do `kbd_mode -a'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
 "    (perhaps you want to do `kbd_mode -u'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, fuzzy, c-format
 msgid "Cannot find %s\n"
 msgstr "No se encontró el tipo %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, fuzzy, c-format
 msgid "cannot open file %s\n"
 msgstr "No se pudo abrir el fichero de tipo de letra %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
 "\t%s [-C console] [-o map.orig]\n"
 msgstr "Uso: %s [-C consola] [-o mapa.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Línea de entrada incorrecta: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr ""
 "%s: el número de glifo (0x%x) es mayor que la longitud del tipo de letra\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: fin de rango (0x%x) incorrecto\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: rango Unicode correspondiente al rango de posición de tipo de letra 0x"
 "%x-0x%x incorrecto\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -671,22 +671,22 @@ msgstr ""
 "%s: el rango Unicode U+%x-U+%x no es de la misma longitud que el rango de "
 "posición 0x%x-0x%x en el tipo de letra\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: se descarta la basura del final (%s)\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Cargando la tabla asociativa unicode del archivo %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Advertencia: la línea es demasiado larga\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -695,87 +695,87 @@ msgstr ""
 "%s: no se carga una tabla asociativa unicode vacía\n"
 "(para forzar a cargarla, use la opción -f)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "entrada"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "entradas"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Se ha guardado la tabla asociativa unicode en `%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Se ha añadido una tabla asociativa Unicode\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "uso: %s [-v] [-o tabla.orig] fichero-tabla-asociativa\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: no puede abrir el fichero-tabla-asociativa _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "No se puede hacer stat() sobre el fichero-tabla-asociativa"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr ""
 "Cargando tabla asociativa de pantalla binaria directa-a-tipo de letra desde "
 "el fichero %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Error de lectura de la tabla asociativa contenida en el fichero `%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Cargando el mapa de pantalla binario unicode desde el fichero %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Cargando el mapa de pantalla simbólico desde el fichero %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Error al analizar el mapa simbólico contenido en `%s', línea %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Error al escribir la tabla asociativa en el fichero\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "No se puede leer la tabla asociativa de consola\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Guardada la tabla asociativa de pantalla en `%s'\n"
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -791,11 +791,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr ""
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, fuzzy, c-format
 msgid "%s: Illegal vt number"
 msgstr "openvt: %s: número de term. virt. erróneo\n"
@@ -844,96 +844,96 @@ msgstr "openvt: usando la terminal virtual %s\n"
 msgid "Cannot open %s read/write"
 msgstr "openvt: No se puede abrir %s para lectura/escritura (%s)\n"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr ""
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr ""
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, fuzzy, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "%s: no se pudo liberar la consola %d\n"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: tabla ucs2 unicode abreviada\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: tabla utf8 unicode abreviada\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: utf8 incorrecto\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: error utf8 desconocido\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: tabla unicode abreviada\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Error al leer el tipo de letra de entrada"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Llamada a readpsffont incorrecta\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: modalidad (%d) de fichero psf no admitida\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Versión (%d) de psf no admitida\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: ¿la longitud del tipo de letra introducido es cero?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: ¿el tamaño del carácter introducido es cero?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Fichero de entrada: longitud de entrada (%d) incorrecta\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Fichero de entrada: basura al final\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: unicode %u es erróneo\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "No se puede escribir la cabecera del fichero de tipo de letra"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "No se pudo escribir el fichero de tipos de letra "
@@ -1013,40 +1013,50 @@ msgstr "%s: fichero psf con número mágico incorrecto\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: el fichero de entrada no tiene un índice\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: no se encuentra el fichero de modos de video %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: no se encuentra el fichero de modos de video %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Número de líneas inválido\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Modo anterior: %dx%d  Modo nuevo: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 "Antes Num._Códigos_de_Rastreo: %d  Ahora Num._Códigos_de_Rastreo: %d  Altura "
 "del carácter: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: la orden `%s' devuelve error\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: no olvide cambiar TERM (quizás a con%dx%d o a linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1059,41 +1069,41 @@ msgstr ""
 "o: resizecons -lines FILAS, donde FILAS es 25, 28, 30, 34, 36, 40, 44, 50, o "
 "60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: no se pueden obtener permisos de Entrada/Salida (I/O).\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "uso: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "Error al leer %s\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "no se pudo leer %s, y no se puede volcar con ioctl\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "no se pudo leer %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Extraño ... ¿¿la pantalla es a la vez %dx%d y %dx%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Error al escribir el volcado de pantalla\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1159,12 +1169,12 @@ msgstr ""
 "\n"
 "Los ficheros se cargan del directorio actual o de /%s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: demasiados ficheros de entrada\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1173,126 +1183,126 @@ msgstr ""
 "setfont: no se puede recuperar a la vez de la ROM de caracteres y de "
 "archivo. No se ha modificado el tipo.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Altura de carácter incorrecta: %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Anchura de carácter incorrecta: %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: la posición 32 en el tipo no es un blanco\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: eliminado\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: el fondo va a tener un aspecto extraño\n"
 
 # Tengo que conservar el orden de los %d aunque
 # en español sería `tipo de caracteres'
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Cargando, de %d caract., el tipo %dx%d desde el fichero %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Cargando, de %d caract., el tipo %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Cargando, de %d caract., el tipo %dx%d (%d)  desde el fichero %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Cargando, de %d caract., el tipo %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: error en do_loadtable()\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Cargando la tabla asociativa Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "No se pudo abrir el fichero de tipo de letra %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Cuando se cargan varios tipos, todos deben ser ficheros psf - %s no lo es\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Leer, de %d caract., el tipo %dx%d a partir del fichero %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Cuando se cargan varios tipos, todos deben tener la misma altura\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "Cuando se cargan varios tipos, todos deben tener el mismo ancho\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "No se encontró el tipo predefinido\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "No se encontró el tipo %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Leyendo el fichero de tipo de letra %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Falta Nueva Línea final en el fichero combinado\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Demasiados ficheros que combinar\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr ""
 "Hmm - ¿un tipo derivado de un restorefont? Usaremos la primera mitad.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Tamaño de fichero de entrada incorrecto\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1301,23 +1311,23 @@ msgstr ""
 "Este fichero contiene tres tipos: 8x8, 8x14 y 8x16. Por favor indique\n"
 "cuál quiere cargar mediante una opción -8, -14 ó -16.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr "Ha pedido un tipo de %d puntos, pero sólo son posibles 8, 14 ó 16.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "No se encontró nada que guardar\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr ""
 "Se ha guardado el fichero de tipos %2$dx%3$d de %1$d caracteres en %4$s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1328,19 +1338,19 @@ msgstr ""
 " (donde código_de_rastreo es ó xx ó e0xx, en hexadecimal,\n"
 " y código_de_tecla se da en decimal)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "se espera un número par de argumentos"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "error al leer el código de rastreo"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "código fuera de los límites"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "no se pudo asignar el código de rastreo %x al código de tecla %d\n"
@@ -1525,12 +1535,12 @@ msgstr "estado anterior:    "
 msgid "new state:    "
 msgstr "estado nuevo:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "uso: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1550,39 +1560,39 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr ""
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, fuzzy, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "%s: %s: Advertencia: la línea es demasiado larga\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "error al restaurar la tabla de traducciones original\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "error al restaurar la tabla asociativa unimap original\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "no se puede cambiar de tabla de traducciones\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1628,16 +1638,16 @@ msgid ""
 "\n"
 msgstr "Cargando, de %d caract., el tipo %dx%d\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "¿DESCONOCIDO?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "el modo del teclado era %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1646,12 +1656,12 @@ msgstr ""
 "[ si lo está intentando bajo las X, podría no funcionar\n"
 "ya que el servidor X también está leyendo /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "se recibió la señal %d, limpiando...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1709,29 +1719,29 @@ msgstr "pulsada"
 msgid "keycode %3d %s\n"
 msgstr "código de tecla %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 #, fuzzy
 msgid "usage: totextmode\n"
 msgstr "uso: getkeycodes\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1740,7 +1750,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1761,16 +1771,16 @@ msgstr ""
 "argumento desconocido: _%s_\n"
 "\n"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "%s: la terminal virtual 1 es la consola y no puede liberarse\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNU kbd 1.15.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2012-12-28 10:27+0200\n"
 "Last-Translator: Jean-Baka Domelevo Entfellner <domelevo@gmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -20,48 +20,48 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "syntaxe : chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
 "Impossible d'obtenir un descripteur de fichier faisant référence à la console"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s : option inconnue\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s : 0 est un numéro de terminal virtuel illégal\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s : le terminal virtuel 1 est la console et ne peut être désalloué\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s : ne peut désallouer la console %d\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys version %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -101,7 +101,7 @@ msgstr ""
 "      --compose-only    affiche seulement les combinaisons de touches\n"
 "   -c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -110,24 +110,24 @@ msgstr ""
 "\t\t\t    interprète les codes d'action de caractère à partir\n"
 "\t\t\t    du jeu de caractères spécifié\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "jeu de caractères inconnu %s - requête de jeu de caractères ignorée\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s : erreur lors de la lecture du mode du clavier : %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -138,7 +138,7 @@ msgstr ""
 "(valeur numérique, symbole)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -162,45 +162,33 @@ msgstr ""
 "\t-n --next-available  affiche le numéro du prochain terminal virtuel "
 "disponible\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Impossible de lire le numéro de terminal virtuel :"
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Impossible d'ouvrir %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr ""
-"Impossible d'obtenir le descripteur de fichier faisant référence à la "
-"console\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "syntaxe : getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "scancodes bruts xx (hex) contre codes clavier (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 est une erreur ; les scancodes de 1 à 88 (0x01-0x58) sont égaux aux codes "
 "clavier\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "pour 1-%d (0x01-0x%02x) les scancodes sont égaux aux codes clavier\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -211,12 +199,12 @@ msgstr ""
 "\n"
 "Scancodes d'échappement e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "échec lors de l'obtention du code clavier pour le scancode 0x%x\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -250,73 +238,73 @@ msgstr "Erreur : pas assez d'arguments !\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Erreur ! Action non reconnue : %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "syntaxe : kbd_mode [-a|-u|-k|-s] [-C device]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Le clavier est en mode brut (scancodes)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Le clavier est en mode semi-brut (codes clavier)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Le clavier est en mode ASCII (mode par défaut)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Le clavier est en mode Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Le clavier est en mode inconnu\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Le vitesse Typematic est réglée à %.1f cps (délai = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Syntaxe : kbdrate [-V] [-s] [-r vitesse] [-d délai]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Ne peut ouvrir /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "bug : getfont a été appelé avec un compteur < 256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr ""
 "bug : l'utilisation de GIO_FONT avec getfont nécessite la mise en mémoire "
 "tampon.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s : mémoire épuisée\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "étrange... le terminal courant est passé de %d à %d.\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -325,23 +313,40 @@ msgstr ""
 "Ce noyau semble antérieur à la version 1.1.92.\n"
 "Pas de table Unicode chargée.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Impossible d'ouvrir %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr ""
+"Impossible d'obtenir le descripteur de fichier faisant référence à la "
+"console\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s à partir de %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s : mémoire épuisée\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "Erreur d'écriture de la mappe dans le fichier\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "impossible: n'est pas meta ?\n"
@@ -361,72 +366,72 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, fuzzy, c-format
 msgid "unable to get keymap %d"
 msgstr "désalloue la mappe de clavier %d\n"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "échec lors de la liaison de la touche %d à la valeur %d\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, fuzzy, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "addkey a été appelé avec le keycode erroné %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "l'ajout de la mappe %d viole une ligne de keymaps explicite"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr "échec lors de la liaison de la touche %d à la valeur %d\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 #, fuzzy
 msgid "impossible error in lk_add_constants"
 msgstr "erreur impossible dans do_constant"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "on suppose iso-8859-1 %s\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "on suppose iso-8859-15 %s\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "on suppose iso-8859-2 %s\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "on suppose iso-8859-3 %s\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "on suppose iso-8859-4 %s\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "keysym inconnu « %s »\n"
@@ -475,13 +480,13 @@ msgstr "%s : impossible de désallouer ou d'effacer la mappe de clavier\n"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "%s : impossible de revenir au mode d'origine du clavier\n"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, fuzzy, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr ""
 "échec lors de la tentative de liaison de la chaîne « %s » à la fonction %s\n"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, fuzzy, c-format
 msgid "failed to clear string %s"
 msgstr "échec lors de l'effacement de la chaîne %s\n"
@@ -491,7 +496,7 @@ msgstr "échec lors de l'effacement de la chaîne %s\n"
 msgid "too many compose definitions"
 msgstr "trop de définitions de combinaisons de touches\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -502,7 +507,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, fuzzy, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -513,14 +518,14 @@ msgstr[1] ""
 "\n"
 "A changé %d %s et %d %s.\n"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "trop de définitions de combinaisons de touches\n"
 msgstr[1] "trop de définitions de combinaisons de touches\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "(Aucun changement dans les définitions de combinaisons de touches.)\n"
@@ -595,7 +600,7 @@ msgstr ""
 "\n"
 "Nom des modifcateurs reconnus et leur numéro de colonne :\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, fuzzy, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -639,17 +644,12 @@ msgstr ""
 "  -u --unicode       force la conversion vers Unicode\n"
 "  -v --verbose       affiche les modifications\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s à partir de %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s : Les options --unicode et --ascii s'excluent mutuellement\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -658,7 +658,7 @@ msgstr ""
 "%s : attention ! Chargement d'une mappe non Unicode sur une console Unicode\n"
 "    (peut-être voudrez-vous faire un `kbd_mode -a' ?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -667,17 +667,17 @@ msgstr ""
 "%s : attention ! Chargement d'une mappe Unicode sur une console non Unicode\n"
 "    (peut-être voudrez-vous faire un `kbd_mode -u' ?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Impossible de trouver %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "Impossible d'ouvrir le fichier %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -686,29 +686,29 @@ msgstr ""
 "Syntaxe:\n"
 "\t%s [-C console] [-o mappe.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Ligne d'entrée erronée : %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr ""
 "%s : le numéro de glyphe (0x%x) est plus grand que la longueur de la fonte\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s : borne supérieure erronée (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s : plage Unicode erronée correspondant aux fontes en position 0x%x à 0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -717,22 +717,22 @@ msgstr ""
 "%s : la plage Unicode U+%x-U+%x n'a pas la même longueur que la plage des "
 "fontes allant de 0x%x à 0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s : caractères finaux (%s) ignorés\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Chargement de la carte unicode à partir du fichier %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s : %s : AVERTISSEMENT : ligne trop longue\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -741,88 +741,88 @@ msgstr ""
 "%s : ne peut charger une unimap vide\n"
 "(utiliser l'option -f pour passer outre)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "entrée"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "entrées"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Mappe unicode sauvegardée dans « %s »\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Mappe Unicode concaténée\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "syntaxe : %s [-v] [-o mappe.orig] fichier-de-mappe\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn : ne peut ouvrir le fichier de mappe _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Ne peut évaluer le fichier par stat()"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr ""
 "Chargement de la mappe d'écran direct-à-la-fonte à partir du fichier %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Erreur de lecture de la mappe à partir du fichier « %s »\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Chargement de la mappe d'écran Unicode à partir du fichier %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Chargement de la mappe symbolique d'écran à partir du fichier %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr ""
 "Erreur d'analyse syntaxique de la mappe symbolique à partir de « %s », ligne "
 "%d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Erreur d'écriture de la mappe dans le fichier\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Ne peut lire la mappe de la console\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "La mappe d'écran a été sauvegardée dans « %s »\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -856,11 +856,11 @@ msgstr ""
 "  -h, --help          afficher un bref message d'aide.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Impossible de déterminer le propriétaire du terminal courant !"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s : numéro de terminal virtuel invalide"
@@ -910,96 +910,96 @@ msgstr "Utilisation du terminal virtuel %s"
 msgid "Cannot open %s read/write"
 msgstr "Impossible d'ouvrir %s en lecture/écriture"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Impossible d'activer le terminal virtuel %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Activation interrompue ?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Impossible de désallouer la console %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s : table abrégée ucs2 unicode\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s : table abrégée utf8 unicode\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s : utf8 erroné\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s : erreur utf8 inconnue\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s : table abrégée unicode\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s : erreur lors de la lecture de la fonte"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s : appel erroné à readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s : mode du fichier psf non pris en charge (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s : version psf non prise en charge (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s : longueur nulle pour la fonte d'entrée ?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s : caractère entré de taille nulle ?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s : fichier d'entrée : longueur erronée (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s : fichier d'entrée: rebut à la fin\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode : unicode illégal %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Ne peut écrire l'en-tête du fichier de fontes"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Ne peut écrire le fichier de fonte"
@@ -1085,39 +1085,49 @@ msgstr "%s : fichier psf avec un nombre magique inconnu\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s : la fonte d'entrée n'a pas d'index\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons : ne peut repérer le fichier videomode %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons : ne peut repérer le fichier videomode %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Nombre de lignes invalide\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Ancien mode : %dx%d  Nouveau mode: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 "Ancien #scanlines: %d  Nouveau #scanlines: %d  Hauteur des caractères: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons : échec de la commande « %s »\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: ne pas oublier de changer TERM (soit con%dx%d ou linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1130,41 +1140,41 @@ msgstr ""
 "ou resizecons -lines LIGNES où LIGNES vaut 25, 28, 30, 34, 36, 40, 44, 50 ou "
 "60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons : ne peut obtenir les permissions d'entrée/sortie (I/O).\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "syntaxe : screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "Erreur de lecture sur %s\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "ne peut lire %s, et ne peut effectuer une vidange ioctl()\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "ne peut lire %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Étrange... l'écran est à la fois %dx%d et %dx%d ?!\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Erreur lors de la production de la vidange screendump\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1223,12 +1233,12 @@ msgstr ""
 "    -V                 affiche la version et quitter.\n"
 "Les fichiers sont chargés à partir du répertoire courant ou de %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: trop de fichiers à l'entrée\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1237,131 +1247,131 @@ msgstr ""
 "setfont: ne peut restaurer les caractères de la ROM et du fichier. Fonte "
 "inchangée.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Heuteur de caractère erronée %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Largeur de caractère erronée %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s : la position 32 de la fonte n'est pas un blanc\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s : a été effacé\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s : l'arrière-plan aura l'air bizarre\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Chargement de %d carac. de la fonte %dx%d à partir du fichier %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Chargement de %d carac. de la fonte %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr ""
 "Chargement de %d carac. de la fonte %dx%d (%d) à partir du fichier %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Chargement de %d carac. de la fonte %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s : bug dans do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Chargement de la table de mapping Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Ne peut ouvrir le fichier de fonte %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Lors du chargement de plusieurs fontes, elles doivent toutes être des fontes "
 "psf - %s ne l'est pas\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Lecture de %d carac. de la fonte %dx%d à partir du fichier %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 "Lors du chargement de plusieurs fontes, elles doivent toutes avoir la même "
 "hauteur\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Lors du chargement de plusieurs fontes, elles doivent toutes avoir la même "
 "largeur\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Ne peut repérer la fonte par défaut\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Ne peut repérer la fonte %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Lecture du fichier de fonte %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Pas de ligne finale dans le ficheir combiné\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Trop de fichiers à combiner\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr ""
 "Euh - une police à partir d'un restorefont ? On utilisera la première "
 "moitié.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Taille erronée du fichier d'entrée\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1370,24 +1380,24 @@ msgstr ""
 "Ce fichier contient 3 fontes: 8x8, 8x14 et 8x16. SVP indiquer\n"
 "laquelle vous désirez charger à l'aide de l'option -8, -14 ou -16.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Vous avez demandé une taille de fonte %d, mais seul 8, 14, 16 est possible "
 "ici.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Il n'y a rien à sauvegarder\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "%d carac. de la fonte %dx%d sauvegardée dans le fichier %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1398,19 +1408,19 @@ msgstr ""
 " (où le scancode est soit xx ou e0xx en hexadécimal,\n"
 "  et le keycode est en décimal)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "nombre paire d'arguments attendu"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "erreur lors de la lecture du scancode"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "code en dehors des bornes"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "échec d'initialisation du scancode %x au keycode %d\n"
@@ -1597,12 +1607,12 @@ msgstr "ancien état :    "
 msgid "new state:    "
 msgstr "nouvel état :    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "syntaxe : %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1634,39 +1644,39 @@ msgstr ""
 "puis éditez les valeurs dans FICHIER.\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Erreur : %s : valeur invalide dans le champ %u à la ligne %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Erreur : %s : pas assez de champs sur la ligne %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Erreur : %s : la ligne %u se termine prématurément.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Erreur ! %s : la ligne %u est trop longue.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "échec de restauration de la table originale de traduction\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "échec de restauration de la mappe unimap originale\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "ne peut modifier la table de traduction\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1715,16 +1725,16 @@ msgstr ""
 "Montre la fonte %d-char\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?INCONNU?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "le mode clavier était %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1733,12 +1743,12 @@ msgstr ""
 "[ si vous essayez cela sous X Window, cela peut ne pas fonctionner\n"
 "étant donné que le serveur X utilise également /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "signal %d reçu, nettoyage en cours...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1797,28 +1807,28 @@ msgstr "appuyé"
 msgid "keycode %3d %s\n"
 msgstr "code clavier %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "Syntaxe : totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr "Merci de réessayer plus tard.\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "L'affichage en mode console est entièrement verrouillé par %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "Le %s est désormais verrouillé par %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 "Utiliser Alt+F1, Alt+F2… pour basculer vers les autres consoles virtuelles."
@@ -1828,7 +1838,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr "Essayer `%s --help' pour plus d'informations.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1856,16 +1866,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "utilisateur non reconnu"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "stdin n'est pas un terminal (tty)"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Ce terminal (%s) n'est pas une console virtuelle.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "L'affichage en mode console ne peut être intégralement verrouillé.\n"

--- a/po/gr.po
+++ b/po/gr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 1.08\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2003-02-16 20:56+0200\n"
 "Last-Translator: Lefteris Dimitroulakis <edimitro@tee.gr>\n"
 "Language-Team: Greek <nls@tux.hellug.gr>\n"
@@ -17,48 +17,48 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: KBabel 0.9.6\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "χρήση: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 #, fuzzy
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Δε μπορώ να λάβω περιγραφέα αρχείου που αφορά την κονσόλα\n"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: άγνωστη επιλογή\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s: 0: παράτυπος αριθμός VT\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s: VT 1 είναι η κονσόλα και δε μπορεί ν' αποδεσμευτεί\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s: αδυναμία αποδέσμευσης της κονσόλας %d\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys έκδοση %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -97,7 +97,7 @@ msgstr ""
 "\t   --compose-only    εμφάνιση μόνο των συνδιασμών των πλήκτρων\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -106,24 +106,24 @@ msgstr ""
 "\t\t\t    διερμηνεία κωδικών των χαρακτήρων ενέργειας\n"
 "\t\t\t    από το προδιαγεγραμμένο σύνολο χαρακτήρων\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "άγνωστο σύνολο χαρακτήρων %s - η αίτηση αγνοήθηκε\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: σφάλμα κατά τον ορισμό της κατάστασης πληκτρολογίου\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -134,7 +134,7 @@ msgstr ""
 "(αριθμητική τιμή, σύμβολο)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -148,47 +148,37 @@ msgid ""
 "\t-n --next-available  display number of next unallocated VT\n"
 msgstr ""
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 #, fuzzy
 msgid "Couldn't read VTNO: "
 msgstr "αδύνατη ανάγνωση %s\n"
 
-#: src/getfd.c:69
-#, fuzzy, c-format
-msgid "Couldn't open %s\n"
-msgstr "αδύνατη ανάγνωση %s\n"
-
-#: src/getfd.c:86
-#, fuzzy, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Δε μπορώ να λάβω περιγραφέα αρχείου που αφορά την κονσόλα\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "χρήση: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr ""
 "Απλοί κωδικοί σάρωσης xx (hex) και οι αντίστοιχοι κωδικοί πλήκτρων (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 είναι ένα σφάλμα; για 1-88 (0x01-0x58) ο κωδικός σάρωσης ισούται με τον "
 "κωδικό πλήκτρου\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, fuzzy, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 "0 είναι ένα σφάλμα; για 1-88 (0x01-0x58) ο κωδικός σάρωσης ισούται με τον "
 "κωδικό πλήκτρου\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -199,12 +189,12 @@ msgstr ""
 "\n"
 "Κωδικοί σάρωσης διαφυγής e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "αποτυχία κατά τη λήψη κωδικού πλήκτρου για τον κώδικα σάρωσης 0x%x\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, fuzzy, c-format
 msgid ""
 "Usage:\n"
@@ -236,94 +226,109 @@ msgstr ""
 "μη αναγνωρισμένα ορίσματα: _%s_\n"
 "\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, fuzzy, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "χρήση: kbd_mode [-a|-u|-k|-s]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται σε ακατέργαστη (scancode) κατάσταση\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται σε ημικατεργασμένη (keycode) κατάσταση\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται στην προεπιλεγμένη κατάσταση (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται σε κατάσταση Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Το πληκτρολόγιο βρίσκεται σε κάποια άγνωστη κατάσταση\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Ο ρυθμός επανάληψης ρυθμίστηκε σε %.1f cps (καθυστέρηση = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Χρήση: kbdrate [-V] [-s] [-r ρυθμός] [-d καθυστέρηση]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Αδυναμία ανοίγματος του /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "bug: getfont κλήθηκε με μετρητή<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr ""
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: η μνήμη εξαντλήθηκε\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr ""
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
 "No Unicode mapping table loaded.\n"
 msgstr ""
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, fuzzy, c-format
+msgid "Couldn't open %s\n"
+msgstr "αδύνατη ανάγνωση %s\n"
+
+#: src/libcommon/getfd.c:86
+#, fuzzy, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Δε μπορώ να λάβω περιγραφέα αρχείου που αφορά την κονσόλα\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s από %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s: η μνήμη εξαντλήθηκε\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "Σφάλμα εγγραφής της απεικόνισης στο αρχείο\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "αδύνατον: δεν είναι meta;\n"
@@ -343,71 +348,71 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, fuzzy, c-format
 msgid "unable to get keymap %d"
 msgstr "openvt: Δε μπορώ ν' ανοίξω το %s: %s\n"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "αποτυχία απόδοσης του κωδικού σάρωσης %x στον κωδικό πλήκτρου %d\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr ""
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr "αποτυχία απόδοσης του κωδικού σάρωσης %x στον κωδικό πλήκτρου %d\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, fuzzy, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "openvt: Δε μπορώ ν' ανοίξω το %s: %s\n"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "υποθέτοντας iso-8859-1 %s\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "υποθέτοντας iso-8859-15 %s\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "υποθέτοντας iso-8859-2 %s\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "υποθέτοντας iso-8859-3 %s\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "υποθέτοντας iso-8859-4 %s\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "άγνωστο keysym '%s'\n"
@@ -456,12 +461,12 @@ msgstr "%s: αδυναμία αποδέσμευσης της κονσόλας %d
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "%s: σφάλμα κατά τον ορισμό της κατάστασης πληκτρολογίου\n"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, fuzzy, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "αποτυχία απόδοσης του κωδικού σάρωσης %x στον κωδικό πλήκτρου %d\n"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, fuzzy, c-format
 msgid "failed to clear string %s"
 msgstr "αποτυχία αποκατάστασης αρχικού unimap\n"
@@ -471,7 +476,7 @@ msgstr "αποτυχία αποκατάστασης αρχικού unimap\n"
 msgid "too many compose definitions"
 msgstr "μέγιστος αριθμός συνθέτων προσδιορισμών: %d\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -482,21 +487,21 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "μέγιστος αριθμός συνθέτων προσδιορισμών: %d\n"
 msgstr[1] "μέγιστος αριθμός συνθέτων προσδιορισμών: %d\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "μέγιστος αριθμός συνθέτων προσδιορισμών: %d\n"
@@ -567,7 +572,7 @@ msgstr ""
 "\n"
 "Ονόματα αναγνωρισμένων μετατροπέων και οι αριθμοί τους στήλης :\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -592,71 +597,66 @@ msgid ""
 "  -V --version       print version number\n"
 msgstr ""
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s από %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
 "    (perhaps you want to do `kbd_mode -a'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
 "    (perhaps you want to do `kbd_mode -u'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, fuzzy, c-format
 msgid "Cannot find %s\n"
 msgstr "Αδυνατώ να βρω τη γραμματοσειρά %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, fuzzy, c-format
 msgid "cannot open file %s\n"
 msgstr "Αδύνατο το άνοιγμα του αρχείου γραμματοσειράς %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, fuzzy, c-format
 msgid ""
 "Usage:\n"
 "\t%s [-C console] [-o map.orig]\n"
 msgstr "χρήση: %s [-v] [-o map.orig] αρχείο-map\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Εσφαλμένη γραμμή εισόδου: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr ""
 "%s: Αριθμός γλύφου (0x%x) μεγαλύτερος απ' το μήκος της γραμματοσειράς\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Εσφαλμένο πέρας περιοχής (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Εσφαλμένη Unicode περιοχή που αντιστοιχεί στην περιοχή θέσεων 0x%x-0x"
 "%xτης γραμματοσειράς.\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -665,22 +665,22 @@ msgstr ""
 "%s: Unicode περιοχή U+%x-U+%x όχι του ιδίου μήκους με την περιοχή θέσεων 0x"
 "%x-0x%x της γραμματοσειράς\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: αγνοήθηκαν σκουπίδια στο τέλος (%s)\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Φόρτωση της απεικόνισης unicode από το αρχείο %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Προειδοποίηση: πολύ μεγάλη γραμμή\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -689,89 +689,89 @@ msgstr ""
 "%s: δε φορτώνεται άδειο unimap\n"
 "(αν επιμένετε: χρησιμοποιείστε την επιλογή -f για παράβλεψη)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "καταχώρηση"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "καταχωρήσεις"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Η απεικόνιση unicode αποθηκεύθηκε στο `%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Προσαρτήθηκε απεικόνιση Unicode\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "χρήση: %s [-v] [-o map.orig] αρχείο-map\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: αδυνατώ ν' ανοίξω το αρχείο απεικόνισης _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Δε μπορώ να αξιολογήσω το αρχείο απεικόνισης με τη stat()"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr ""
 "Φόρτωση δυαδικής απεικόνισης της οθόνης απευθείας-στη-γραμματοσειρά από το "
 "αρχείο %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Σφάλμα ανάγνωσης απεικόνισης από το αρχείο `%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Φόρτωση της δυαδικής unicode απεικόνισης της οθόνης από το αρχείο %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Φόρτωση της συμβολικής απεικόνισης της οθόνης από το αρχείο %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr ""
 "Σφάλμα κατά τη γραμματοσυντακτική ανάλυσητης συμβολικής απεικόνισης από `"
 "%s', γραμμή %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Σφάλμα εγγραφής της απεικόνισης στο αρχείο\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Αδυναμία ανάγνωσης της απεικόνισης της κονσόλας\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Η απεικόνιση της οθόνης αποθηκεύθηκε στο `%s'\n"
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -787,11 +787,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr ""
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, fuzzy, c-format
 msgid "%s: Illegal vt number"
 msgstr "openvt: %s: παράτυπος αριθμός vt\n"
@@ -841,98 +841,98 @@ msgstr "openvt: χρησιμοποίηση VT %s\n"
 msgid "Cannot open %s read/write"
 msgstr "openvt: Δε μπορώ ν' ανοίξω το %s για ανάγνωση/εγγραφή (%s)\n"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, fuzzy, c-format
 msgid "Couldn't activate vt %d"
 msgstr ""
 "\n"
 "openvt: αδύνατον το άνοιγμα του %s σε Α/Ε (%s)\n"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr ""
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, fuzzy, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "%s: αδυναμία αποδέσμευσης της κονσόλας %d\n"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: λειψός πίνακας unicode usc2\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: λειψός πίνακας utf8 unicode\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: εσφαλμένο utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: άγνωστο σφάλμα utf8\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: λειψός πίνακας unicode\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Σφάλμα κατά την ανάγνωση της γραμματοσειράς"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Εσφαλμένη κλήση της readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Μη υποστηριζόμενη κατάσταση αρχείου psf (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Μή υποστηριζόμενη έκδοση psf (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: μηδέν μήκος γραμματοσειράς εισόδου;\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: μηδέν μέγεθος χαρακτήρα εισόδου;\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Αρχείο εισόδου: εσφαλμένο μήκος εισόδου (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Αρχείο εισόδου: σκουπίδια στο τέλος\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: παράτυπο unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Αδυναμία εγγραφής της επικεφαλίδας του αρχείου γραμματοσειράς"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Δε μπορώ να γράψω στο αρχείο της γραμματοσειράς"
@@ -1018,38 +1018,48 @@ msgstr "%s: αρχείο psf με άγνωστο μαγικό αριθμό\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: η γραμματοσειρά εισόδου δεν περιέχει ευρετήριο\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: αδυνατώ να βρω το αρχείο videomode %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: αδυνατώ να βρω το αρχείο videomode %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Άκυρος αριθμός γραμμών\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Παλαιά κατάσταση: %dx%d  Νέα κατάσταση: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Παλαιές #scanlines: %d  Νέες #scanlines: %d  Ύψος χαρακτήρα: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: αποτυχία εντολής `%s'\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: μή ξεχνάτε την αλλαγή του TERM (ίσως σε con%dx%d ή linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1062,42 +1072,42 @@ msgstr ""
 "ή: resizecons -lines ΓΡΑΜΜΕΣ, με ΓΡΑΜΜΕΣ μία από 25, 28, 30, 34, 36, 40, 44, "
 "50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: αδύνατη η λήψη δικαιωμάτων I/O.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "χρήση: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "Σφάλμα ανάγνωσης %s\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr ""
 "αδυναμία ανάγνωσης του %s, και δε μπορώ να το εμφανίσω με την ioctl()\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "αδύνατη ανάγνωση %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Περίεργο ...η οθόνη είναι συγχρόνως %dx%d και %dx%d ;;\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Σφάλμα εγγραφής screendump\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1153,12 +1163,12 @@ msgstr ""
 "    -V           Εμφάνιση πληροφοριών έκδοσης κι έξοδος.\n"
 "Τα αρχεία φορτώνονται από τον τρέχοντα κατάλογο ή από %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: πάρα πολλά αρχεία εισόδου\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1167,126 +1177,126 @@ msgstr ""
 "setfont: αδύνατη επαναφορά από τη ROM χαρακτήρων και από αρχείο συγχρόνως. Η "
 "γραμματοσειρά παραμένει αμετάβλητη.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Εσφαλμένο ύψος χαρακτήρα %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Εσφαλμένο πλάτος χαρακτήρα %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: η θέση 32 της γραμματοσειράς δεν είναι κενή\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: το καθάρισα\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: το παρασκήνιο θα φαίνεται αλλόκοτο\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d από το αρχείο %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d (%d) από το αρχείο %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: σφάλμα στο do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Φόρτωση πίνακα απεικόνισης Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Αδύνατο το άνοιγμα του αρχείου γραμματοσειράς %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Κατά τη φόρτωση διαφόρων γραμμ/σειρών, όλες πρέπει να είναι psf - %s δεν "
 "είναι\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Ανάγνωση %d-χαρακτ. της γραμματοσειράς %dx%d από το αρχείο %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 "Κατά τη φόρτωση πολλών γραμματοσειρών, όλες πρέπει να έχουν το ίδιο ύψος\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Κατά τη φόρτωση πολλών γραμματοσειρών, όλες πρέπει να έχουν ίδιο πλάτος\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Αδυνατώ να βρω την προεπιλεγμένη γραμματοσειρά\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Αδυνατώ να βρω τη γραμματοσειρά %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Ανάγνωση αρχείου γραμματοσειράς %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Δεν υπάρχει τελική νέα γραμμή στο συνδιασμένο αρχείο\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Πάρα πολλά αρχεία για συνδιασμό\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Χμμ - γραμματοσειρά από το restorefont; Χρήση του πρώτου μισού.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Εσφαλμένο μέγεθος αρχείου εισόδου\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1295,24 +1305,24 @@ msgstr ""
 "Αυτό το αρχείο περιέχει 3 γραμματοσειρές: 8x8, 8x14 και 8x16. Παρακαλώ\n"
 "υποδείξτε με τις επιλογές -8 ή -14 ή -16 ποια θέλετε.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Ζητήσατε μέγεθος γραμματοσειράς %d, αλλά μόνον 8, 14, 16\n"
 "είναι δυνατόν εδώ.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Τίποτε για διάσωση\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "%d-χαρακτ. της γραμματοσειράς %dx%d διασώθηκαν στο αρχείο %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1323,19 +1333,19 @@ msgstr ""
 " (όπου ο scancode είναι xx ή e0xx, σε δεκαεξαδική μορφή,\n"
 "  και ο keycode σε δεκαδική)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "αναμενόταν ζυγός αριθμός ορισμάτων "
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "σφάλμα ανάγνωσης κωδικού σάρωσης"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "κωδικός εκτός ορίων"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "αποτυχία απόδοσης του κωδικού σάρωσης %x στον κωδικό πλήκτρου %d\n"
@@ -1517,12 +1527,12 @@ msgstr "παλαιά κατάσταση:        "
 msgid "new state:    "
 msgstr "νέα κατάσταση:       "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "χρήση: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1542,39 +1552,39 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr ""
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, fuzzy, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "%s: %s: Προειδοποίηση: πολύ μεγάλη γραμμή\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "αποτυχία αποκατάστασης αρχικού πίνακα μετάφρασης\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "αποτυχία αποκατάστασης αρχικού unimap\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "αδυνατώ ν' αλλάξω τον πίνακα μετάφρασης\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1611,16 +1621,16 @@ msgid ""
 "\n"
 msgstr "Φόρτωση των %d-χαρακτ. της γραμμ/σειράς %dx%d\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr ";ΑΓΝΩΣΤΟ;"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "Η κατάσταση kb ήταν %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1629,12 +1639,12 @@ msgstr ""
 "[ αν το προσπαθείτε στα Χ, ίσως να μη δουλεύει\n"
 "αφού κι ο εξυπηρετητής Χ διαβάζει επίσης το /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "ελήφθη το σήμα %d, καθαρισμός...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1691,29 +1701,29 @@ msgstr "πάτημα"
 msgid "keycode %3d %s\n"
 msgstr "κωδικός πλήκτρου %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 #, fuzzy
 msgid "usage: totextmode\n"
 msgstr "χρήση: getkeycodes\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1722,7 +1732,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1743,16 +1753,16 @@ msgstr ""
 "μη αναγνωρισμένα ορίσματα: _%s_\n"
 "\n"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "%s: VT 1 είναι η κονσόλα και δε μπορεί ν' αποδεσμευτεί\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 1.15.2\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2010-07-07 23:30+0700\n"
 "Last-Translator: Arif E. Nugroho <arif_endro@yahoo.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -17,49 +17,49 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "penggunaan: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 #, fuzzy
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
 "Tidak dapat memperoleh deskripsi berkas yang mereferensikan ke konsole\n"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: pilihan tidak diketahui\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s: 0: nomor VT tidak legal\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s: VT 1 adalah konsole dan tidak dapat didealokasikan\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s: tidak dapat didealokasikan console %d\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys versi %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -97,7 +97,7 @@ msgstr ""
 "\t   --compose-only   tampilkan hanya kombinasi tombol compose\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -106,24 +106,24 @@ msgstr ""
 "\t\t\t    interpretasikan aksi kode karakter dari\n"
 "\t\t\t    set karakter yang dispesifikasikan\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "charset %s tidak diketahui - mengabaikan permintaan charset\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: error membaca mode keyboard\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -134,7 +134,7 @@ msgstr ""
 "(nilai numerik, simbol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -157,43 +157,32 @@ msgstr ""
 "\t-V --version         tampilkan informasi versi\n"
 "\t-n --next-available  tampilkan VT yang belum dialokasikan selanjutnya\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Tidak dapat membaca VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Tidak dapat membuka %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr ""
-"Tidak dapat memperoleh deskripsi berkas yang mereferensikan ke konsole\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "penggunaan: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Plain scancodes xx (hex) lawan keycodes (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 adalah sebuah error; untuk 1-88 (0x01-0x58) scancode sama dengan keycode\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "untuk 1-%d (0x01-0x%02x) scancode sama dengan keycode\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -204,12 +193,12 @@ msgstr ""
 "\n"
 "Escaped scancodes e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "gagal memperoleh keycode untuk scancode 0x%x\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -241,94 +230,110 @@ msgstr ""
 "argumen tidak diketahui: _%s_\n"
 "\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "penggunaan: kbd_mode [-a|-u|-k|-s] [-C perangkat]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Keyboard sekarang dalam mode raw (scancode)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Keyboard sekarang dalam mode mediumraw (keycode)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Keyboard sekarang dalam mode baku (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Keyboard sekarang dalam mode Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Keyboard sekarang dalam mode tidak dikenal\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Typematic Rate diset ke %.1f cps (tunda = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Penggunaan: kbdrate [-V] [-s] [-r rate] [-d tunda]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Tidak dapat membuka /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "bug: getfont dipanggil dengan count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "bug: getfont menggunakan GIO_FONT membutuhkan buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: kehabisan memori\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr ""
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
 "No Unicode mapping table loaded.\n"
 msgstr ""
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Tidak dapat membuka %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr ""
+"Tidak dapat memperoleh deskripsi berkas yang mereferensikan ke konsole\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s dari %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s: kehabisan memori\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "Error menulis peta ke berkas\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "tidak memungkinkan: bukan meta?\n"
@@ -348,72 +353,72 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, fuzzy, c-format
 msgid "unable to get keymap %d"
 msgstr "dealokasi peta tombol %d\n"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "gagal untuk mengikat tombol %d ke nilai %d\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, fuzzy, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "addkey dipanggil dengan kode tombol %d buruk"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "menambahkan peta %d melanggar baris peta-kunci eksplisit"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr "gagal untuk mengikat tombol %d ke nilai %d\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 #, fuzzy
 msgid "impossible error in lk_add_constants"
 msgstr "tidak mungkin error dalam do_constant"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "mengasumsikan iso-8859-1 %s\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "mengasumsikan iso-8859-15 %s\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "mengasumsikan iso-8859-2 %s\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "mengasumsikan iso-8859-3 %s\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "mengasumsikan iso-8859-4 %s\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "keysym '%s' tidak diketahui\n"
@@ -462,12 +467,12 @@ msgstr "%s: tidak dapat dealokasikan atau menghapus peta-tombol\n"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "%s: tidak dapat kembali ke mode keyboard asli\n"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, fuzzy, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "gagal untuk mengikat string '%s' ke fungsi %s\n"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, fuzzy, c-format
 msgid "failed to clear string %s"
 msgstr "gagal untuk menghapus string %s\n"
@@ -477,7 +482,7 @@ msgstr "gagal untuk menghapus string %s\n"
 msgid "too many compose definitions"
 msgstr "terlalu banyak definisi compose\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -488,7 +493,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, fuzzy, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -499,14 +504,14 @@ msgstr[1] ""
 "\n"
 "Diubah %d %s dan %d %s.\n"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "terlalu banyak definisi compose\n"
 msgstr[1] "terlalu banyak definisi compose\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "(Tidak ada perubahan dalam definisi compose.)\n"
@@ -576,7 +581,7 @@ msgstr ""
 "\n"
 "Nama pemodifikasi dikenal dan jumlah kolomnya:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, fuzzy, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -618,17 +623,12 @@ msgstr ""
 "  -u --unicode       konversi implisit ke Unicode\n"
 "  -v --verbose       laporkan perubahan\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s dari %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, fuzzy, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -637,7 +637,7 @@ msgstr ""
 "%s: peringatan: memuat peta-kunci Unicode dalam console tidak-Unicode\n"
 "    (mungkin anda ingin melakukan `kbd_mode -u'?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -646,17 +646,17 @@ msgstr ""
 "%s: peringatan: memuat peta-kunci Unicode dalam console tidak-Unicode\n"
 "    (mungkin anda ingin melakukan `kbd_mode -u'?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Tidak dapat menemukan %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "tidak dapat membuka berkas %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -665,29 +665,29 @@ msgstr ""
 "Penggunaan:\n"
 "\t%s [-C console] [-o map.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Baris masukan buruk: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Nomor glyph (0x%x) lebih besar dari panjang font\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Akhir dari jangkauan (0x%x) buruk\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Jangkauan unicode yang berhubungan ke posisi font dalam daerah 0x%x-0x%x "
 "buruk\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -696,22 +696,22 @@ msgstr ""
 "%s: Daerah unicoe U+%x-U+%x tidak dari panjang yang sama seperti posisi font "
 "daerah 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: akhiran sampah (%s) diabaikan\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Menload peta unicode dari berkas %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Peringatan: baris terlalu panjang\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -720,85 +720,85 @@ msgstr ""
 "%s: tidak meload unimap kosong\n"
 "(jika anda tetap memaksa: gunakan pilihan -f untuk memaksa)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "masukan"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "masukan"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Disimpan peta unicode di `%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Ditambahkan peta unicode\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "penggunaan: %s [-v] [-o peta.asal] berkas-peta]\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: tidak dapat membuka berkas peta _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Tidak dapat memperoleh statistik berkas peta"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Meload binari langsung ke font peta layar dari berkas %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Error membaca peta dari berkas `%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Meload binari unicode peta layar dari berkas %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Meload simbolik peta layar dari berkas %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Error parsing peta simbolik dari `%s', baris %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Error menulis peta ke berkas\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Tidak dapat membaca peta console\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Peta layar disimpan dalam `%s'\n"
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -814,12 +814,12 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 #, fuzzy
 msgid "Couldn't find owner of current tty!"
 msgstr "Tidak dapat menemukan pemilik dari tty sekarang!\n"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, fuzzy, c-format
 msgid "%s: Illegal vt number"
 msgstr "openvt: %s: nomor vt tidak legal\n"
@@ -868,101 +868,101 @@ msgstr "openvt: menggunakan VT %s\n"
 msgid "Cannot open %s read/write"
 msgstr "openvt: Tidak dapat membuka %s baca/tulis (%s)\n"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, fuzzy, c-format
 msgid "Couldn't activate vt %d"
 msgstr ""
 "\n"
 "openvt: tidak dapat mengaktifkan vt %d (%s)\n"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 #, fuzzy
 msgid "Activation interrupted?"
 msgstr ""
 "\n"
 "openvt: aktivasi terinterupsi? (%s)\n"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, fuzzy, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "%s: tidak dapat didealokasikan console %d\n"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: short ucs2 tabel unicode\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: short utf8 tabel unicode\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: utf8 buruk\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: error utf8 tidak diketahui\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: tabel unicode pendek\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Error membaca font masukan"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Panggilan dari readpsffont buruk\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Mode berkas psf (%d) tidak didukung\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Versi psf tidak didukung (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: panjang masukan font nol?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: ukuran masukan karakter nol?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Berkas masukan: panjang masukan buruk (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Berkas masukan: akhiran sampah\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: unicode %u tidak legal\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Tidak dapat menulis font berkas header"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Tidak dapat menulis berkas font"
@@ -1048,31 +1048,41 @@ msgstr "%s: berkas psf dengan magik tidak diketahui\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: font masukan tidak memiliki sebuah indeks\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: tidak dapat menemukan berkas videomode %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: tidak dapat menemukan berkas videomode %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Jumlah dari baris tidak valid\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Mode lama: %dx%d Mode baru: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Lama #scanlines: %d Baru #scanlines: %d Tinggi karakter: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: perintah `%s' gagal\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1080,7 +1090,7 @@ msgstr ""
 "resizecons: jangan lupa untuk mengubah TERM (mungkin ke con%dx%d atau linux-"
 "%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1093,41 +1103,41 @@ msgstr ""
 "atau: resizecons -lines ROWS, dengan ROWS satu dari 25, 28, 30, 34, 36, 40, "
 "44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: tidak dapat memperoleh ijin I/O.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "penggunaan: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "Error membaca %s\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "tidak dapat membaca %s, dan tidak dapat dump ioctl\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "tidak dapat membaca %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Aneh ... layar baik %dx%d dan %dx%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Error menulis screendump\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1182,12 +1192,12 @@ msgstr ""
 "    -V         Tampilkan versi dan keluar.\n"
 "Berkas yang dilad dari direktori sekarang atau %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: terlalu banyak berkas masukan\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1196,124 +1206,124 @@ msgstr ""
 "setfont: tidak dapat baik mengembalikan dari karakter ROM dan dari berkas."
 "Font tidak berubah.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Tinggi karakter buruk %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Lebar karakter buruk %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: posisi font 32 adalah bukan blank\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: disapu\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: background akan kelihatan lucu\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Meload %d-char %dx%d font dari berkas %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Meload %d-char %dx%d font\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Meload %d-char %dx%d (%d) font dari berkas %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Meload %d-char %dx%d (%d) font\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: bug dalam do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Meload tabel peta Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Tidak dapat membuka berkas font %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr "Ketika meload beberapa font, semua harus berupa font psf - %s bukan\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Baca %d-char %dx%d font dari berkas %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Ketika meload beberapa font, semua harus memiliki tinggi yang sama\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "Ketika meload beberapa fonts, semua harus memiliki lebar yang sama\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Tidak dapat menemukan font baku\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Tidak dapat menemukan font %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Membaca berkas font %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Tidak ada final baris baru dalam kombinasi berkas\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Terlalu banyak berkas untuk dikombinasikan\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr ""
 "Hmm - sebuah font dari restorefont? Menggunakan potongan setengah yang "
 "pertama.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Ukuran berkas masukan buruk\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1323,24 +1333,24 @@ msgstr ""
 "dengan menggunakan sebuah pilihan -8 atau -14 atau -16 mana yang anda ingin "
 "load.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Anda bertanya untuk ukuran font %d, tetapi hanya 8, 14, 16 yang memungkinkan "
 "disini.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Ditemukan nothing untuk disimpan\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Disimpan %d-char %dx%d font berkas di %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1351,19 +1361,19 @@ msgstr ""
 " (dimana scancode baik xx atau e0xx, diberikan dalam heksa desimal,\n"
 "  dan keycode diberikan dalam desimal)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "jumlah genap dari argumen diduga"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "error membaca scancode"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "kode diluar jangkauan"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "gagal untuk menset scancode %x ke keycode %d\n"
@@ -1543,12 +1553,12 @@ msgstr "keadaan lama: "
 msgid "new state:    "
 msgstr "keadaan baru:  "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "penggunaan: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1568,39 +1578,39 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr ""
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, fuzzy, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "%s: %s: Peringatan: baris terlalu panjang\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "gagal untuk merestore tabel terjemahan asli\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "gagal untuk mengembalikan unimap asli\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "tidak dapat mengubah tabel terjemahan\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1648,16 +1658,16 @@ msgstr ""
 "Menampilkan %d-char font\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?TIDAK DIKETAHUI?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "kb mode adalah %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1666,12 +1676,12 @@ msgstr ""
 "[ jika anda mencoba ini dibawah X, ini mungkin tidak bekerja\n"
 "karena X server juga membaca /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "menangkap sinyal %d, membersihkan...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1728,29 +1738,29 @@ msgstr "tekan"
 msgid "keycode %3d %s\n"
 msgstr "keycode %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 #, fuzzy
 msgid "usage: totextmode\n"
 msgstr "penggunaan: getkeycodes\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1759,7 +1769,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1780,16 +1790,16 @@ msgstr ""
 "argumen tidak diketahui: _%s_\n"
 "\n"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "%s: VT 1 adalah konsole dan tidak dapat didealokasikan\n"

--- a/po/id.po
+++ b/po/id.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-1\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd-1.15.3-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2011-06-13 00:36+0200\n"
 "Last-Translator: Sergio Zanchetta <primes2h@ubuntu.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -18,48 +18,48 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural= (n != 1)\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "uso: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
 "Impossibile ottenere un descrittore di file che si riferisca alla console"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: opzione sconosciuta\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s: 0: numero di terminale virtuale non consentito\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s: il terminale virtuale 1 è la console e non può essere deallocata\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s: impossibile deallocare la console %d\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys versione %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -96,7 +96,7 @@ msgstr ""
 "\t   --compose-only   Visualizza solo le combinazioni del tasto compose\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -105,25 +105,25 @@ msgstr ""
 "\t\t\t    Interpreta i codici azione per i caratteri come derivanti dal\n"
 "\t\t\t    set di caratteri specificato\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr ""
 "set di caratteri %s sconosciuto - richiesta del set di caratteri ignorata\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: errore nella lettura della modalità di tastiera\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -134,7 +134,7 @@ msgstr ""
 "(valore numerico, simbolo)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -158,45 +158,34 @@ msgstr ""
 "\t-n --next-available  Mostra il numero di terminale virtuale non allocato "
 "successivo\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Impossibile leggere il n. del terminale virtuale (VTNO): "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Impossibile aprire %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr ""
-"Impossibile ottenere un descrittore di file che si riferisce alla console\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "uso: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Codici di scansione xx in chiaro (hex) contro codici di tasto (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 è un errore; per 1-88 (0x01-0x58) il codice di scansione è uguale al "
 "codice di tasto\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 "per 1-%d (0x01-0x%02x) il codice di scansione è uguale al codice di tasto\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -207,13 +196,13 @@ msgstr ""
 "\n"
 "Codici di scansione per sequenze di escape e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "recupero del codice di tasto per il codice di scansione 0x%x non riuscito\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -249,71 +238,71 @@ msgstr ""
 "Errore, azione non riconosciuta: %s\n"
 "\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "uso: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "La tastiera si trova in modalità raw (codice di scansione)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "La tastiera si trova in modalità mediumraw (codice di tasto)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "La tastiera si trova in modalità predefinita (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "La tastiera si trova in modalità Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "La tastiera si trova in qualche modalità sconosciuta\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "\"Typematic Rate\" impostato a %.1f cps (ritardo = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Uso: kbdrate [-V] [-s] [-r frequenza] [-d ritardo]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Impossibile aprire /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "bug: chiamata a getfont con contatore<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "bug: getfont usa GIO_FONT e necessita del buffer\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: memoria esaurita\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "strano... ct è cambiato da %d a %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -322,23 +311,39 @@ msgstr ""
 "Sembra che questo kernel sia antecedente al 1.1.92\n"
 "Nessuna tabella di mappatura Unicode caricata.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Impossibile aprire %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr ""
+"Impossibile ottenere un descrittore di file che si riferisce alla console\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s da %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s: memoria esaurita\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "Errore nella scrittura della mappa sul file\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "impossibile: forse non è meta\n"
@@ -358,72 +363,72 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, fuzzy, c-format
 msgid "unable to get keymap %d"
 msgstr "deallocazione della mappatura %d\n"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "associazione del tasto %d al valore %d non riuscita\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, fuzzy, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "addkey chiamata con codice di tasto %d errato"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "l'aggiunta della mappa %d vìola la riga delle mappature esplicite"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr "associazione del tasto %d al valore %d non riuscita\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 #, fuzzy
 msgid "impossible error in lk_add_constants"
 msgstr "errore impossibile in do_constant"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "si assume iso-8859-1 %s\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "si assume iso-8859-15 %s\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "si assume iso-8859-2 %s\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "si assume iso-8859-3 %s\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "si assume iso-8859-4 %s\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "simbolo di tasto \"%s\" sconosciuto\n"
@@ -472,12 +477,12 @@ msgstr "%s: impossibile deallocare o cancellare la mappatura\n"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "%s: impossibile ripristinare la modalità originaria della tastiera\n"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, fuzzy, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "associazione della stringa \"%s\" alla funzione %s non riuscita\n"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, fuzzy, c-format
 msgid "failed to clear string %s"
 msgstr "cancellazione della stringa %s non riuscita\n"
@@ -487,7 +492,7 @@ msgstr "cancellazione della stringa %s non riuscita\n"
 msgid "too many compose definitions"
 msgstr "troppe definizioni compose\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -498,7 +503,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, fuzzy, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -509,14 +514,14 @@ msgstr[1] ""
 "\n"
 "Cambiato %d %s e %d %s.\n"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "troppe definizioni compose\n"
 msgstr[1] "troppe definizioni compose\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "(Nessuna modifica nelle definizioni compose.)\n"
@@ -586,7 +591,7 @@ msgstr ""
 "\n"
 "Nomi dei modificatori rilevati e relativi numeri di colonna:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, fuzzy, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -629,17 +634,12 @@ msgstr ""
 "  -u --unicode       Forza la conversione a Unicode\n"
 "  -v --verbose       Riporta le modifiche\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s da %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: le opzioni --unicode e --ascii sono mutuamente esclusive\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -648,7 +648,7 @@ msgstr ""
 "%s: attenzione, caricata una mappatura non Unicode su una console Unicode\n"
 "    (forse si vuole eseguire \"kbd_mode -a\")\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -657,17 +657,17 @@ msgstr ""
 "%s: attenzione, caricata una mappatura Unicode su una console non Unicode\n"
 "    (forse si vuole eseguire \"kbd_mode -u\")\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Impossibile trovare %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "impossibile aprire il file %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -676,30 +676,30 @@ msgstr ""
 "Uso:\n"
 "\t%s [-C console] [-o map.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Riga di input errata: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr ""
 "%s: numero di glifo (0x%x) più grande della lunghezza del tipo di carattere\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: fine dell'intervallo errata (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: intervallo Unicode errato in corrispondenza dell'intervallo di posizione "
 "del carattere 0x%x-0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -708,22 +708,22 @@ msgstr ""
 "%s: l'intervallo Unicode U+%x-U+%x non ha la stessa lunghezza "
 "dell'intervallo di posizione del carattere 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: spazzatura a fine riga (%s) ignorata\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Caricamento della mappa Unicode dal file %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: attenzione: riga troppo lunga\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -732,85 +732,85 @@ msgstr ""
 "%s: mappa Unimap vuota non caricata\n"
 "(se si insiste: usare l'opzione -f per sovrascrivere)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "voce"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "voci"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Mappa Unimap salvata su \"%s\"\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Mappa Unimap accodata\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "uso: %s [-v] [-o map.orig] file-mappa\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: impossibile aprire il file di mappa _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Impossibile fare stat del file di mappa"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Caricamento della mappa schermo binaria direct-to-font dal file %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Errore nella lettura della mappa dal file \"%s\"\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Caricamento della mappa schermo binaria Unicode dal file %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Caricamento della mappa schermo simbolica dal file %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Errore nell'analisi della mappa simbolica da \"%s\", riga %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Errore nella scrittura della mappa sul file\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Impossibile leggere la mappa della console\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Mappa schermo salvata in \"%s\"\n"
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -842,11 +842,11 @@ msgstr ""
 "  -h, --help          Mostra un breve messaggio di aiuto.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Impossibile trovare il proprietario del tty corrente."
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: numero di terminale virtuale non consentito"
@@ -896,96 +896,96 @@ msgstr "Viene usato il terminale virtuale %s"
 msgid "Cannot open %s read/write"
 msgstr "Impossibile aprire %s in lettura/scrittura"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Impossibile attivare il terminale virtuale %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Forse l'attivazione è stata interrotta"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Impossibile deallocare la console %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: tabella Unicode UCS-2 corta\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: tabella Unicode UTF-8 corta\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: UTF-8 errata\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: errore UTF-8 sconosciuto\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: tabella Unicode corta\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: errore nella lettura del carattere di input"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: chiamata a readpsffont errata\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: modo file psf non supportato (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: versione psf non supportata (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: forse la lunghezza del tipo di carattere in input è zero\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: forse la dimensione del carattere in input è zero\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: file di input: lunghezza in input errata (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: file di input: spazzatura alla fine della riga\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: carattere Unicode %u non consentito\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Impossibile scrivere l'intestazione del file di carattere"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Impossibile scrivere il file di carattere"
@@ -1071,31 +1071,41 @@ msgstr "%s: file psf con numero magico sconosciuto\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: il carattere di input non ha un indice\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: impossibile trovare il file delle modalità video %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: impossibile trovare il file delle modalità video %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Numero di righe non valido\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Vecchia modalità: %dx%d  Nuova modalità: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Vecchie #scanlines: %d  Nuove #scanlines: %d  Altezza carattere: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: comando \"%s\" non riuscito\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1103,7 +1113,7 @@ msgstr ""
 "resizecons: non dimenticarsi di cambiare TERM (forse in con%dx%d o linux-%dx"
 "%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1116,41 +1126,41 @@ msgstr ""
 "o: resizecons -lines RIGHE, con RIGHE uno tra 25, 28, 30, 34, 36, 40, 44, "
 "50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: impossibile ottenere i permessi di I/O.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "uso: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "Errore nel leggere %s\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "impossibile leggere %s ed effettuare l'ioctl di dump\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "impossibile leggere %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Strano ... lo schermo è sia %dx%d che %dx%d \n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Errore in scrittura di screendump\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1208,12 +1218,12 @@ msgstr ""
 "    -V         Stampa la versione ed esce.\n"
 "I file sono caricati dalla directory corrente o da %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: troppi file di input\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1222,129 +1232,129 @@ msgstr ""
 "setfont: impossibile ripristinare sia dalla ROM caratteri che dal file. "
 "Carattere non modificato.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Altezza errata del carattere %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Larghezza errata del carattere %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: la posizione carattere 32 non rappresenta uno spazio\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: pulito\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: lo sfondo sarà strano\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Caricamento del tipo di carattere %d-char %dx%d dal file %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Caricamento del tipo di carattere %d-char %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Caricamento del tipo di carattere %d-char %dx%d (%d) dal file %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Caricamento del tipo di carattere %d-char %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: bug in do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Caricamento della tabella di mappatura Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Impossibile aprire il file di carattere %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Quando vengono caricati diversi tipi di carattere, devono essere tutti di "
 "tipo psf - %s non lo è\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Lettura del tipo di carattere %d-char %dx%d dal file %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 "Quando vengono aperti diversi tipi di carattere, devono avere tutti la "
 "stessa altezza\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Quando vengono aperti diversi tipi di carattere, devono avere tutti la "
 "stessa larghezza\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Impossibile trovare il tipo di carattere predefinito\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Impossibile trovare il tipo di carattere %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Lettura del file di carattere %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Nessun carattere newline finale nel file da unire\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Troppi file da unire\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr ""
 "Hmm - un tipo di carattere da restorefont. Ne viene usata la prima metà.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Dimensione errata del file di input\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1353,24 +1363,24 @@ msgstr ""
 "Questo file contiene 3 tipi di carattere: 8x8, 8x14 e 8x16. Indicare,\n"
 "usando l'opzione -8, -14 o -16, quale si desidera caricare.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "È stato richiesto %d come dimensione di carattere, ma i valori possibili "
 "sono solo 8, 14 e 16.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Non è stato trovato nulla da salvare\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "File del carattere di tipo %d-char %dx%d salvato su %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1381,19 +1391,19 @@ msgstr ""
 " (dove codicescansione è o xx oppure e0xx, fornito in esadecimale,\n"
 "  e codicetasto è fornito in decimale)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "atteso un numero pari di argomenti"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "errore nella lettura del codice di scansione"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "codice fuori dai limiti"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1578,12 +1588,12 @@ msgstr "stato vecchio:  "
 msgid "new state:    "
 msgstr "stato nuovo:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "uso: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1613,39 +1623,39 @@ msgstr ""
 "e quindi modificare i valori nel FILE.\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Errore: %s, valore non valido nel campo %u riga %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Errore: %s, numero insufficiente di campi nella riga %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Errore: %s, la riga %u è terminata in modo inatteso.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Errore: %s, la riga %u è troppo lunga.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "ripristino della tabella di traduzione originale non riuscito\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "ripristino unimap originale non riuscito\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "impossibile cambiare la tabella di traduzione\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1695,16 +1705,16 @@ msgstr ""
 "Tipo di carattere %d-char\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?SCONOSCIUTO?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "la modalità della tastiera era %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1713,12 +1723,12 @@ msgstr ""
 "[ Se questo tentativo viene effettuato usando X potrebbe non\n"
 "funzionare, dato che anche il server X sta leggendo /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "catturato segnale %d, pulizia...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1775,28 +1785,28 @@ msgstr "premuto"
 msgid "keycode %3d %s\n"
 msgstr "codice tasto %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "uso: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1805,7 +1815,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1826,16 +1836,16 @@ msgstr ""
 "argomento non riconosciuto: _%s_\n"
 "\n"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "%s: il terminale virtuale 1 è la console e non può essere deallocata\n"

--- a/po/kbd.pot
+++ b/po/kbd.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,45 +18,45 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr ""
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr ""
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr ""
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr ""
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr ""
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr ""
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -77,31 +77,31 @@ msgid ""
 "\t-c --charset="
 msgstr ""
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
 "\t\t\t    specified character set\n"
 msgstr ""
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr ""
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr ""
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -109,7 +109,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -123,41 +123,31 @@ msgid ""
 "\t-n --next-available  display number of next unallocated VT\n"
 msgstr ""
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr ""
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr ""
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr ""
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr ""
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr ""
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -165,12 +155,12 @@ msgid ""
 "Escaped scancodes e0 xx (hex)\n"
 msgstr ""
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -198,92 +188,107 @@ msgstr ""
 msgid "Error: Unrecognized action: %s\n"
 msgstr ""
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr ""
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr ""
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr ""
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr ""
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr ""
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr ""
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr ""
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr ""
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr ""
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr ""
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr ""
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr ""
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr ""
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
 "No Unicode mapping table loaded.\n"
 msgstr ""
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr ""
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr ""
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr ""
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr ""
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr ""
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr ""
@@ -303,71 +308,71 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr ""
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr ""
@@ -416,12 +421,12 @@ msgstr ""
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr ""
@@ -430,7 +435,7 @@ msgstr ""
 msgid "too many compose definitions"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -441,21 +446,21 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr ""
 
@@ -519,7 +524,7 @@ msgid ""
 "Recognized modifier names and their column numbers:\n"
 msgstr ""
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -544,175 +549,170 @@ msgid ""
 "  -V --version       print version number\n"
 msgstr ""
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr ""
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
 "    (perhaps you want to do `kbd_mode -a'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
 "    (perhaps you want to do `kbd_mode -u'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr ""
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr ""
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
 "\t%s [-C console] [-o map.orig]\n"
 msgstr ""
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr ""
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr ""
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr ""
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
 "%x-0x%x\n"
 msgstr ""
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr ""
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr ""
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr ""
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
 "(if you insist: use option -f to override)\n"
 msgstr ""
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr ""
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr ""
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr ""
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr ""
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr ""
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr ""
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr ""
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr ""
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr ""
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr ""
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr ""
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr ""
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr ""
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr ""
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr ""
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -728,11 +728,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr ""
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr ""
@@ -778,96 +778,96 @@ msgstr ""
 msgid "Cannot open %s read/write"
 msgstr ""
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr ""
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr ""
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr ""
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr ""
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr ""
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr ""
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr ""
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr ""
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr ""
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr ""
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr ""
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr ""
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr ""
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr ""
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr ""
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr ""
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr ""
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr ""
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr ""
@@ -942,37 +942,47 @@ msgstr ""
 msgid "%s: input font does not have an index\n"
 msgstr ""
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr ""
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr ""
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr ""
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr ""
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr ""
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -981,41 +991,41 @@ msgid ""
 "60\n"
 msgstr ""
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr ""
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr ""
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr ""
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr ""
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr ""
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr ""
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr ""
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1044,156 +1054,156 @@ msgid ""
 "Files are loaded from the current directory or %s/*/.\n"
 msgstr ""
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr ""
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
 "unchanged.\n"
 msgstr ""
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr ""
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr ""
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr ""
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr ""
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr ""
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr ""
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr ""
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr ""
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr ""
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr ""
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr ""
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr ""
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr ""
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr ""
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr ""
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr ""
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr ""
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr ""
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr ""
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr ""
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
 "using an option -8 or -14 or -16 which one you want loaded.\n"
 msgstr ""
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr ""
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr ""
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1201,19 +1211,19 @@ msgid ""
 "  and keycode is given in decimal)\n"
 msgstr ""
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr ""
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr ""
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr ""
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1364,12 +1374,12 @@ msgstr ""
 msgid "new state:    "
 msgstr ""
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr ""
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1389,39 +1399,39 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr ""
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr ""
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr ""
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr ""
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr ""
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1458,28 +1468,28 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr ""
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr ""
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
 "since the X server is also reading /dev/console ]\n"
 msgstr ""
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr ""
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1521,28 +1531,28 @@ msgstr ""
 msgid "keycode %3d %s\n"
 msgstr ""
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr ""
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1551,7 +1561,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1569,16 +1579,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr ""
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd-2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2017-01-07 15:02+0100\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -22,45 +22,45 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 1.0\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "Gebruik:  chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Kan geen bestandsdescriptor verkrijgen die verwijst naar de console"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: onbekende optie\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "ongeldig VT-nummer: 0\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT-1 is de hoofdconsole en kan niet worden vrijgegeven\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "kan console %d niet vrijgeven: ioctl(VT_DISALLOCATE)"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys, versie %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -98,7 +98,7 @@ msgstr ""
 "      --compose-only      alleen de samenstellingstoetscombinaties tonen\n"
 "  -c, --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -106,7 +106,7 @@ msgid ""
 msgstr ""
 "                       tekenactiecodes via deze tekenset interpreteren\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -115,17 +115,17 @@ msgstr ""
 "  -v, --verbose         uitgebreidere uitvoer produceren\n"
 "  -V, --version         programmaversie tonen\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "onbekende tekenset '%s' -- tekensetverzoek wordt genegeerd\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: fout tijdens lezen van toetsenbordmodus: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -137,7 +137,7 @@ msgstr ""
 "(waarde, symbool)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -161,42 +161,32 @@ msgstr ""
 "  -h, --help              deze hulptekst tonen\n"
 "  -V, --version           programmaversie tonen\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Kan VT-nummer niet lezen: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Kan %s niet openen\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Kan geen bestandsdescriptor verkrijgen die verwijst naar de console\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "Gebruik:  getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Ruwe scancodes xx (hex) tegenover toetscodes (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 is een fout; voor 1-88 (0x01-0x58) is de scancode gelijk aan de toetscode\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "voor 1-%d (0x01-0x%02x) is de scancode gelijk aan de toetscode\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -207,13 +197,13 @@ msgstr ""
 "\n"
 "Geëscapede scancodes e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "opvragen van toetscode voor scancode 0x%x is mislukt: ioctl(KDGETKEYCODE)"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -249,73 +239,73 @@ msgstr "Fout: te weinig argumenten.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Fout: onbekende actie: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "Gebruik:  kbd_mode [-a|-u|-k|-s] [-C apparaat]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Het toetsenbord is in ruwe (scancode-)modus\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Het toetsenbord is in halfbakken (toetscode-)modus\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Het toetsenbord is in de standaard modus (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Het toetsenbord is in Unicode-modus (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Het toetsenbord is in een onbekende modus\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr ""
 "Toetssnelheid is ingesteld op %.1f tekens per seconde (vertraging = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr ""
 "Gebruik:  kbdrate [-V|--version] [-s] [-r frequentie] [-d vertraging]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Kan /dev/port niet openen"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "*interne programmafout*: getfont() is aangeroepen met count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "*interne programmafout*: getfont() met GIO_FONT heeft buffer nodig\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: onvoldoende geheugen beschikbaar\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "Vreemd... huidige terminal veranderde van %d naar %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -324,21 +314,36 @@ msgstr ""
 "Deze kernel schijnt ouder te zijn dan versie 1.1.92.\n"
 "Er is geen Unicode-afbeeldingstabel geladen.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Kan %s niet openen\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Kan geen bestandsdescriptor verkrijgen die verwijst naar de console\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s (uit %s)\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "onvoldoende geheugen beschikbaar"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "kan array niet initialiseren: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Fout tijdens schrijven van toetsenkaart naar bestand"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "onmogelijk: niet meta?\n"
@@ -358,71 +363,71 @@ msgstr "KDGKBSENT: %s: kan geen functietoets-tekenreeks verkrijgen"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: kan geen accententabel verkrijgen"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "kan toetsenkaart %d niet verkrijgen"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "kan toets %d niet uitschakelen voor tabel %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key() is aangeroepen met onjuiste toetscode %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "toevoegen van kaart %d schendt expliciete toetsenkaartregel"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "kan toets %d niet instellen voor tabel %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "onmogelijke fout in lk_add_constants()"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "kan symbool niet verkrijgen wegens onjuist type: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "kan symbool van type %d niet verkrijgen wegens onjuiste index: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "iso-8859-1 '%s' wordt aangenomen"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "iso-8859-15 '%s' wordt aangenomen"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "iso-8859-2 '%s' wordt aangenomen"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "iso-8859-3 '%s' wordt aangenomen"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "iso-8859-4 '%s' wordt aangenomen"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "onbekende toetsnaam '%s'\n"
@@ -472,12 +477,12 @@ msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr ""
 "KDSKBMODE: %s: kan niet terugkeren naar oorspronkelijke toetsenbordmodus"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "verbinden van tekenreeks '%s' met functie %s is mislukt"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "wissen van tekenreeks %s is mislukt"
@@ -486,7 +491,7 @@ msgstr "wissen van tekenreeks %s is mislukt"
 msgid "too many compose definitions"
 msgstr "te veel samenstellingsdefinities"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -501,21 +506,21 @@ msgstr[1] ""
 "\n"
 "Er zijn %d toetsen veranderd."
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] "Er is %d tekenreeks veranderd."
 msgstr[1] "Er zijn %d tekenreeksen veranderd."
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "Er is %d samenstellingsdefinitie geladen."
 msgstr[1] "Er zijn %d samenstellingsdefinities geladen."
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Geen verandering in samenstellingsdefinities.)"
 
@@ -585,7 +590,7 @@ msgstr ""
 "Herkende optietoetsnamen en hun kolomnummers:\n"
 "\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -631,17 +636,12 @@ msgstr ""
 "  -h, --help          deze hulptekst tonen\n"
 "  -V, --version       programmaversie tonen\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s (uit %s)\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: de opties '--unicode' en '--ascii' gaan niet samen\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -651,7 +651,7 @@ msgstr ""
 "terminal\n"
 "    (wilt u misschien 'kbd_mode -a' doen?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -661,46 +661,46 @@ msgstr ""
 "terminal\n"
 "    (wilt u misschien 'kbd_mode -u' doen?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Kan %s niet vinden\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "Kan bestand %s niet openen\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
 "\t%s [-C console] [-o map.orig]\n"
 msgstr "Gebruik:  %s [-C console] [-o toetsenkaart.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Ongeldige invoerregel: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Glyph-getal (0x%x) is groter dan lengte van lettertype\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Ongeldig einde van bereik (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Ongeldig Unicode-bereik corresponderend met lettertype-positiebereik 0x"
 "%x-0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -709,22 +709,22 @@ msgstr ""
 "%s: Unicodebereik U+%x-U+%x is niet van dezelfde lengte als lettertype-"
 "positiebereik 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: rommel (%s) aan het einde is genegeerd\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Laden van Unicodekaart uit bestand %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Waarschuwing: regel is te lang\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -733,85 +733,85 @@ msgstr ""
 "%s: lege Unicodekaart wordt niet geladen\n"
 "(als u dit toch wilt, gebruik dan optie '-f')\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "item"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "items"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Unicodekaart is opgeslagen in '%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Unicodekaart is achteraan toegevoegd\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "Gebruik:  %s [-V] [-v] [-o kaart.orig] kaartbestand\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: kan kaartbestand '%s' niet openen\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Kan status van kaartbestand niet opvragen"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Laden van binaire direct-naar-lettertype-schermkaart uit bestand %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Fout tijdens lezen van kaart uit bestand '%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Laden van binaire Unicode-schermkaart uit bestand %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Laden van symbolische schermkaart uit bestand %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Fout tijdens verwerken van symbolische kaart uit '%s', regel %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Fout tijdens schrijven van toetsenkaart naar bestand\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Kan consolekaart niet lezen\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Schermkaart is opgeslagen in '%s'\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -844,11 +844,11 @@ msgstr ""
 "  -V, --version       de programmaversie tonen en stoppen\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Kan eigenaar van huidige tty niet vinden!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: ongeldig VT-nummer"
@@ -898,96 +898,96 @@ msgstr "VT-%s wordt gebruikt"
 msgid "Cannot open %s read/write"
 msgstr "Kan %s niet openen voor lezen-en-schrijven"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Kan VT %d niet activeren"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Activatie onderbroken?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Kan console %d niet vrijgeven"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: korte ucs2-Unicodetabel\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: korte utf8-Unicodetabel\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: ongeldige utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: onbekende utf8-fout\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: korte Unicodetabel\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Fout tijdens lezen van invoerlettertype"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Ongeldige aanroep van 'readpsffont'\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Niet-ondersteunde psf-bestandsmodus (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Niet-ondersteunde psf-versie (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: invoerlettertype met lengte nul?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: invoertekengrootte is nul?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Invoerbestand: ongeldige invoerlengte (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Invoerbestand: rommel aan het einde\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: ongeldige Unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Kan kop van lettertypebestand niet schrijven"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Kan lettertypebestand niet schrijven"
@@ -1066,32 +1066,42 @@ msgstr "%s: psf-bestand met onbekend magisch nummer\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: invoerlettertype heeft geen index\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: kan videomodusbestand %s niet vinden\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: kan videomodusbestand %s niet vinden\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Ongeldig aantal regels\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Oude modus: %dx%d  Nieuwe modus: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 "Oud aantal scanregels: %d  Nieuw aantal scanregels: %d  Tekenhoogte: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: de opdracht '%s' is mislukt\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1099,7 +1109,7 @@ msgstr ""
 "resizecons: vergeet niet TERM te veranderen (mogelijk naar con%dx%d of linux-"
 "%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1112,41 +1122,41 @@ msgstr ""
 "     of:  resizecons -lines RIJEN\n"
 "     (met RIJEN één van 25, 28, 30, 34, 36, 40, 44, 50, 60)\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: kan in-/uitvoer-toegangsrechten niet opvragen\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "Gebruik:  screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Fout bij lezen van %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "kan %s niet lezen, en ioctl() voor meer informatie is mislukt\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "kan %s niet lezen\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Vreemd... het scherm is zowel in %dx%d als in %dx%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Fout bij schrijven van schermafdruk\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1209,12 +1219,12 @@ msgstr ""
 "\n"
 "Bestanden worden geladen uit de huidige map of uit %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: te veel invoerbestanden\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1223,130 +1233,130 @@ msgstr ""
 "setfont: kan niet herstellen uit zowel teken-ROM als bestand -- lettertype "
 "is onveranderd\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Ongeldige tekenhoogte %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Ongeldige tekenbreedte %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: lettertype-positie 32 is niet blanco\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: gewist\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: achtergrond zal er raar uitzien\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Laden van %d-teken %dx%d-lettertype uit bestand %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Laden van %d-teken %dx%d-lettertype\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Laden van %d-teken %dx%d (%d) lettertype uit bestand %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Laden van %d-teken %dx%d (%d) lettertype\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: *interne programmafout* in 'do_loadtable'\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Laden van Unicode-afbeeldingstabel...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Kan lettertypebestand %s niet openen\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Bij het laden van meerdere lettertypen moeten ze allemaal psf-lettertypen "
 "zijn -- %s is dat niet\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Het %d-tekens %dx%d lettertype is gelezen uit bestand %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 "Bij het laden van meerdere lettertypen moeten ze allemaal dezelfde hoogte "
 "hebben\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Bij het laden van meerdere lettertypen moeten ze allemaal dezelfde breedte "
 "hebben\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Kan standaardlettertype niet vinden\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Kan lettertype %s niet vinden\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Lezen van lettertypebestand %s...\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Geen afsluitend regeleinde in combinatiebestand\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Te veel bestanden om te combineren\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr ""
 "Hmm... een lettertype van 'restorefont'?  Alleen eerste helft wordt "
 "gebruikt.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Ongeldige grootte van invoerbestand\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1355,23 +1365,23 @@ msgstr ""
 "Dit bestand bevat drie lettertypen: 8x8, 8x14 en 8x16.\n"
 "Geef met optie '-8', '-14' of '-16' aan welke u wilt laden.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "U vroeg om lettergrootte %d, maar alleen 8, 14 en 16 zijn hier mogelijk.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Niets gevonden om op te slaan\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Het %d-tekens %dx%d lettertypebestand is opgeslagen als %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1382,19 +1392,19 @@ msgstr ""
 "              (SCANCODE is hexadecimaal, te geven als xx of e0xx)\n"
 "              (TOETSCODE is decimaal)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "een even aantal argumenten wordt verwacht"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "fout tijdens lezen van scancode"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "code ligt buiten bereik"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1575,12 +1585,12 @@ msgstr "oude status:    "
 msgid "new state:    "
 msgstr "nieuwe status:  "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "Gebruik:  %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1614,39 +1624,39 @@ msgstr ""
 "  -V    programmaversie tonen\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Fout: %s: ongeldige waarde in veld %u op regel %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Fout: %s: onvoldoende velden op regel %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Fout: %s: regel %u eindigde onverwacht.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Fout: %s: regel %u is te lang.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "herstellen van originele vertaaltabel is mislukt\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "herstellen van originele Unicodekaart is mislukt\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "kan vertaaltabel niet wijzigen\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1695,16 +1705,16 @@ msgid ""
 "\n"
 msgstr "Weergave van lettertype met %d tekens:\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?ONBEKEND?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "toetsenbordmodus was %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1713,12 +1723,12 @@ msgstr ""
 "[ als u dit onder X probeert, werkt het mogelijk niet,\n"
 "  omdat de X server ook /dev/console leest ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "signaal %d ontvangen; bezig met opschonen...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1779,11 +1789,11 @@ msgstr "ingedrukt"
 msgid "keycode %3d %s\n"
 msgstr "toetscode %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "Gebruik:  totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1793,17 +1803,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Het gehele console-scherm is nu volledig vergrendeld door %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "Het %s is nu vergrendeld door %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 "Gebruik Alt+functietoetsen om naar andere virtuele consoles over te "
@@ -1814,7 +1824,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr "Typ '%s --help' voor meer informatie.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1847,16 +1857,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "niet-herkende gebruiker"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "standaardinvoer is geen terminal"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Huidige terminal (%s) is geen virtuele console.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Het gehele console-scherm kan niet vergrendeld worden.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-12-28 16:31+0100\n"
 "Last-Translator: Jakub Bogusz <qboosh@pld-linux.org>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -18,45 +18,45 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "składnia: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Nie udało się uzyskać deskryptora pliku wskazującego na konsolę"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: nieznana opcja\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: błędny numer VT\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 jest konsolą i nie może być zwolniony\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "nie można zwolnić konsoli %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys wersja %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -94,7 +94,7 @@ msgstr ""
 "\t-d --compose-only   wyświetlenie tylko kombinacji compose\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -103,7 +103,7 @@ msgstr ""
 "\t\t\t    interpretowanie kodów znaków jako pochodzących\n"
 "\t\t\t    z podanego zestawu\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -112,17 +112,17 @@ msgstr ""
 "\t-v --verbose\n"
 "\t-V --version\t    wypisanie numeru wersji\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "nieznany zestaw znaków %s - ignorowanie żądania zestawu znaków\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: błąd podczas odczytu trybu klawiatury: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -133,7 +133,7 @@ msgstr ""
 "(wartość liczbowa, symbol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -156,42 +156,32 @@ msgstr ""
 "\t-V --version         wyświetlenie tego opisu\n"
 "\t-n --next-available  wyświetlenie następnego nieprzydzielonego VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Nie udało się odczytać VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Nie udało się otworzyć %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Nie udało się uzyskać deskryptora pliku wskazującego na konsolę\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "składnia: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Zwykłe skankody xx (hex) a kody klawiszy (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 jest błędem; dla 1-88 (0x01-0x58) skankod jest równy kodowi klawisza\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "dla 1-%d (0x01-0x%02x) skankod jest równy kodowi klawisza\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -202,13 +192,13 @@ msgstr ""
 "\n"
 "Specjalne skankody e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "nie udało się odczytać kodu klawisza dla skankodu 0x%x: ioctl KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -245,73 +235,73 @@ msgstr "Błąd: za mało argumentów.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Błąd: Nierozpoznana akcja: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "składnia: kbd_mode [-a|-u|-k|-s] [-C urządzenie]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Klawiatura jest w trybie surowym (skankodów)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Klawiatura jest w trybie średnio surowym (kodów klawiszy)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Klawiatura jest w trybie normalnym (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Klawiatura jest w trybie Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Klawiatura jest w nieznanym trybie\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr ""
 "Częstotliwość powtarzania ustawiono na %.1f zn/sek (opóźnienie = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr ""
 "Składnia: kbdrate [-V | --version] [-s] [-r częstotliwość] [-d opóźnienie]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Nie można otworzyć /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "błąd: getfont wywołane z licznikiem<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "błąd: getfont z użyciem GIO_FONT wymaga bufora.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: brak pamięci\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "dziwne... ct zmieniło się z %d na %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -320,21 +310,36 @@ msgstr ""
 "Wygląda na to, że jądro jest starsze niż 1.1.92\n"
 "Nie wczytano tabeli mapy unikodowej.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Nie udało się otworzyć %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Nie udało się uzyskać deskryptora pliku wskazującego na konsolę\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s z %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "brak pamięci"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "nie udało się zainicjować tablicy: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Błąd podczas zapisu mapy do pliku"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "niemożliwe: nie meta?\n"
@@ -354,71 +359,71 @@ msgstr "KDGKBSENT: %s: Nie udało się pobrać łańcucha klawisza funkcyjnego"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: Nie udało się pobrać tabeli akcentów"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "nie udało się pobrać mapy klawiszy %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "nie udało się usunąć przypisania klawisza %d dla tabeli %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key wywołano z błędnym kodem klawisza %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "dodanie mapy %d narusza jawną linię mapy klawiszy"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "nie udało się przypisać klawisza %d dla tabeli %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "niemożliwy błąd w lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "nie udało się pobrać symbolu poprzez niewłaściwy typ: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "nie udało się pobrać symbolu typu %d poprzez niewłaściwy indeks: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "przyjęto %s w iso-8859-1"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "przyjęto %s w iso-8859-15"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "przyjęto %s w iso-8859-2"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "przyjęto %s w iso-8859-3"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "przyjęto %s w iso-8859-4"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "nieznany symbol '%s'\n"
@@ -467,12 +472,12 @@ msgstr "KDSKBENT: %s: nie udało się zwolnić lub wyczyścić mapy klawiszy"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: nie udało się wrócić do pierwotnego trybu klawiatury"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "nie udało się przypisać łańcucha '%s' do funkcji %s"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "nie udało się wyczyścić łańcucha %s"
@@ -481,7 +486,7 @@ msgstr "nie udało się wyczyścić łańcucha %s"
 msgid "too many compose definitions"
 msgstr "zbyt dużo definicji compose"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -499,7 +504,7 @@ msgstr[2] ""
 "\n"
 "Zmieniono %d klawiszy"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -507,7 +512,7 @@ msgstr[0] "Zmieniono %d łańcuch"
 msgstr[1] "Zmieniono %d łańcuchy"
 msgstr[2] "Zmieniono %d łańcuchów"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
@@ -515,7 +520,7 @@ msgstr[0] "Wczytano %d definicję compose"
 msgstr[1] "Wczytano %d definicje compose"
 msgstr[2] "Wczytano %d definicji compose"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Brak zmian w definicjach compose)"
 
@@ -584,7 +589,7 @@ msgstr ""
 "\n"
 "Rozpoznawane nazwy modyfikatorów i numery ich kolumn:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -629,17 +634,12 @@ msgstr ""
 "  -v --verbose       informowanie o zmianach\n"
 "  -V --version       wyświetlenie numeru wersji\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s z %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: Opcje --unicode i --ascii wykluczają się wzajemnie\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -648,7 +648,7 @@ msgstr ""
 "%s: uwaga: wczytywanie nieunikodowej mapy klawiszy na nieunikodowej konsoli\n"
 "    (być może powinno być jeszcze `kbd_mode -a'?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -657,17 +657,17 @@ msgstr ""
 "%s: uwaga: wczytywanie unikodowej mapy klawiszy na nieunikodowej konsoli\n"
 "    (być może powinno być jeszcze `kbd_mode -u'?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Nie można odnaleźć %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "nie można otworzyć pliku %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -676,28 +676,28 @@ msgstr ""
 "Składnia:\n"
 "\t%s [-C konsola] [-o mapa.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Błędna linia wejściowa: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: numer znaku (0x%x) większy od długości fontu\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Błędny koniec przedziału (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Błędny przedział Unicode odpowiadający przedziałowi 0x%x-0x%x w foncie\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -706,22 +706,22 @@ msgstr ""
 "%s: Przedział Unicode U+%x-U+%x nie jest tej samej długości co 0x%x-0x%x w "
 "foncie\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: zignorowano końcowe śmieci (%s)\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Wczytywanie mapy unikodowej z pliku %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Uwaga: linia zbyt długa\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -730,85 +730,85 @@ msgstr ""
 "%s: nie wczytywanie pustej unimapy\n"
 "(jeśli tak ma być: można wymusić opcją -f)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "wpis"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "wpisów"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Zapisano mapę unikodową w `%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Dołączono mapę unikodową\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "składnia: %s [-V] [-v] [-o mapa.orig] plik-mapy\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: nie można otworzyć pliku mapy _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Nie można wykonać stat na pliku mapy"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Wczytywanie binarnej, bezpośredniej mapy ekranowej z pliku %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Błąd podczas czytania mapy z pliku `%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Wczytywanie binarnej, unikodowej mapy ekranowej z pliku %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Wczytywanie symbolicznej mapy ekranowej z pliku %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Błąd podczas analizy mapy symbolicznej z `%s' w linii %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Błąd podczas zapisu mapy do pliku\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Nie można odczytać mapy konsoli\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Zapisano mapę ekranową w `%s'\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -840,11 +840,11 @@ msgstr ""
 "  -h, --help          wyświetlenie krótkiego opisu użycia\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Nie udało się odnaleźć właściciela bieżącego tty!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: Błędny numer vt"
@@ -894,96 +894,96 @@ msgstr "Użycie VT %s"
 msgid "Cannot open %s read/write"
 msgstr "Nie można otworzyć %s do odczytu i zapisu"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Nie udało się uaktywnić vt %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Uaktywnianie przerwane?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Nie udało się zwolnić konsoli %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: krótka tablica unikodowa ucs2\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: krótka tablica unikodowa utf8\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: błędne utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: nieznany błąd utf8\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: krótka tablica unikodowa\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Błąd podczas odczytu fontu wejściowego"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Błędne wywołanie readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Nie obsługiwany rodzaj pliku psf (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Nie obsługiwana wersja psf (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: font wejściowy zerowej długości?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: znak wejściowy zerowego rozmiaru?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Plik wejściowy: błędna długość wejścia (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Plik wejściowy: końcowe śmieci\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: błędny unikod %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Nie można zapisać nagłówka pliku fontu"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Nie można zapisać pliku fontu"
@@ -1066,37 +1066,47 @@ msgstr "%s: plik psf z nieznanym znacznikiem\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: font wejściowy nie ma indeksu\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: nie można odnaleźć pliku trybów graficznych %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: nie można odnaleźć pliku trybów graficznych %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Błędna liczba linii\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Stary tryb: %dx%d  Nowy tryb: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Stara l.skanlinii: %d  Nowa l.skanlinii: %d  Wysokość znaku: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: polecenie `%s' nie powiodło się\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr "resizecons: trzeba zmienić TERM (może na con%dx%d lub linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1109,41 +1119,41 @@ msgstr ""
 "lub: resizecons -lines WIERSZE\n"
 "gdzie WIERSZE mogą być liczbą jedną z: 25, 28, 30, 34, 36, 40, 44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: nie można uzyskać uprawnień do wejścia/wyjścia\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "składnia: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Błąd podczas czytania %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "nie można odczytać %s, nie można zrzucić ioctl\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "nie można odczytać %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Dziwne... ekran jest jednocześnie %dx%d i %dx%d???\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Błąd podczas zapisu zrzutu ekranu\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1197,12 +1207,12 @@ msgstr ""
 "    -V         Wypisanie informacji o wersji i zakończenie.\n"
 "Pliki są wczytywane z katalogu bieżącego lub %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: zbyt dużo plików wejściowych\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1211,123 +1221,123 @@ msgstr ""
 "setfont: nie można jednocześnie odtworzyć z ROM-u i z pliku. Font nie "
 "zmieniony.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Błędna wysokość znaku %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Błędna szerokość znaku %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: pozycja 32 w foncie nie jest pusta\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: wyczyszczono\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: tło będzie wyglądać zabawnie\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Wczytywanie %d-znakowego fontu %dx%d z pliku %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Wczytywanie %d-znakowego fontu %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Wczytywanie %d-znakowego fontu %dx%d (%d) z pliku %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Wczytywanie %d-znakowego fontu %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: błąd w do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Wczytywanie tablicy odwzorowania Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Nie można otworzyć pliku fontu %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr "Przy wczytywaniu kilku fontów, wszystkie muszą być psf - %s nie jest\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Wczytywanie %d-znakowego fontu %dx%d z pliku %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Przy wczytywaniu kilku fontów, wszystkie muszą mieć tę samą wysokość\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Przy wczytywaniu kilku fontów, wszystkie muszą mieć tę samą szerokość\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Nie można znaleźć domyślnego fontu\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Nie można znaleźć fontu %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Czytanie pliku fontu %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Brak ostatniego znaku końca linii w pliku dołączanym\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Zbyt dużo plików do połączenia\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - font z restorefont? Używanie pierwszej połowy.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Błędny rozmiar pliku wejściowego\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1336,22 +1346,22 @@ msgstr ""
 "Ten plik zawiera 3 fonty: 8x8, 8x14 i 8x16. Proszę podać przy\n"
 "użyciu opcji -8, -14 lub -16, który z nich ma być wczytany.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr "Wybrano rozmiar fontu %d, ale możliwe są tylko 8, 14, 16.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Nie znaleziono nic do zapisania\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Zapisano %d-znakowy font %dx%d do pliku %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1362,19 +1372,19 @@ msgstr ""
 " (gdzie skankod to xx lub e0xx, podany szesnastkowo,\n"
 "  a kod klawisza jest podany dziesiętnie)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "oczekiwano parzystej liczby argumentów"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "błąd podczas czytania skankodu"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "kod spoza zakresu"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1554,12 +1564,12 @@ msgstr "stary stan:   "
 msgid "new state:    "
 msgstr "nowy stan:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "składnia: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1595,39 +1605,39 @@ msgstr ""
 "   -V     wyświetlenie informacji o wersji\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Błąd: %s: Błędna wartość w polu %u w linii %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Błąd: %s: Zbyt mała liczba pól w linii %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Błąd: %s: Nieoczekiwany koniec linii %u.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Błąd: %s: Linia %u jest zbyt długa.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "odtworzenie oryginalnej tablicy translacji nie powiodło się\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "odtworzenie oryginalnej unimapy nie powiodło się\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "nie można zmienić tablicy translacji\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1676,16 +1686,16 @@ msgstr ""
 "Wyświetlanie fontu %d-znakowego\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?NIEZNANY?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "tryb kb był %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1694,12 +1704,12 @@ msgstr ""
 "[ jeśli to jest wykonywane pod X, może nie działać\n"
 "ponieważ X serwer także czyta /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "złapano sygnał %d, sprzątanie...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1756,11 +1766,11 @@ msgstr "naciśnięcie"
 msgid "keycode %3d %s\n"
 msgstr "kod klawisza %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "Składnia: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1770,17 +1780,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Całość konsoli jest całkowicie zablokowana przez użytkownika %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "Terminal %s jest zablokowany przez użytkownika %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 "Można użyć kombinacji Alt-klawisz funkcyjny do przełączenia na inne konsole "
@@ -1791,7 +1801,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr "Polecenie `%s --help' poda więcej informacji.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1818,16 +1828,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "nieznany użytkownik"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "stdin nie jest terminalem"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Ten terminal (%s) nie jest konsolą wirtualną.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Nie można zablokować całości konsoli.\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 1.08\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2003-11-20 17:33+0200\n"
 "Last-Translator: Eugen Hoanca <eugenh@urban-grafx.ro>\n"
 "Language-Team: Romanian <translation-team-ro@lists.sourceforge.net>\n"
@@ -16,50 +16,50 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "folosire: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 #, fuzzy
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
 "Nu am putut gãsi un descriptor de fiºier care sã se refere la aceastã "
 "consolã\n"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: opþiune necunoscutã\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s: 0: numãr VT ilegal\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s: VT 1 este consola ºi nu poate fi dealocatã\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s:nu se poate derepartiza(deallocate) consola %d\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys versiune %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -96,7 +96,7 @@ msgstr ""
 "\t   --compose-only   afiºeazã doar combinaþiile tastelor compuse\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -106,25 +106,25 @@ msgstr ""
 "luate\n"
 "\t\t\t    din setul de caractere specificat\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr ""
 "set de caractere %s necunoscut - se ignorã cererea de set de caractere\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: eroare în setarea modului tastaturii\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -135,7 +135,7 @@ msgstr ""
 "(valoare numericã, simbol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -149,48 +149,36 @@ msgid ""
 "\t-n --next-available  display number of next unallocated VT\n"
 msgstr ""
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 #, fuzzy
 msgid "Couldn't read VTNO: "
 msgstr "nu s-a putut citi %s\n"
 
-#: src/getfd.c:69
-#, fuzzy, c-format
-msgid "Couldn't open %s\n"
-msgstr "nu s-a putut citi %s\n"
-
-#: src/getfd.c:86
-#, fuzzy, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr ""
-"Nu am putut gãsi un descriptor de fiºier care sã se refere la aceastã "
-"consolã\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "folosire: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Scancodes normale(plain) xx (hex) versus keycodes (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 este eroare; pentru 1-88 (0x01-0x58) codul de scan(scancode) egal codul "
 "tastei\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, fuzzy, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 "0 este eroare; pentru 1-88 (0x01-0x58) codul de scan(scancode) egal codul "
 "tastei\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -201,14 +189,14 @@ msgstr ""
 "\n"
 "Coduri scanare de escape e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "eroare în primirea codului de tastã(keycode) pentru codul de scan(scancode) "
 "0x%x\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, fuzzy, c-format
 msgid ""
 "Usage:\n"
@@ -240,94 +228,111 @@ msgstr ""
 "argument necunoscut: _%s_\n"
 "\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, fuzzy, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "folosire: kbd_mode [-a|-u|-k|-s]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Tastatura este în mod brut (scancode)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Tastatura este în mod mediu-brut (keycode)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Tastatura este în modul implicit (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Tastatura este în modul Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Tastatura este într-un mod necunoscut\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Rata de Tipãrire(Typematic) setatã la %.1f cps (întârziere = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Folosire: kbdrate [-V] [-s] [-r ratã] [-d întârziere]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Nu se poate deschide /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "bug: getfont apelat cu numãr(count)<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr ""
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: memorie plinã\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr ""
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
 "No Unicode mapping table loaded.\n"
 msgstr ""
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, fuzzy, c-format
+msgid "Couldn't open %s\n"
+msgstr "nu s-a putut citi %s\n"
+
+#: src/libcommon/getfd.c:86
+#, fuzzy, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr ""
+"Nu am putut gãsi un descriptor de fiºier care sã se refere la aceastã "
+"consolã\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s din %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s: memorie plinã\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "Eroare în scrierea mapãrii în fiºier\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "imposibil: non meta?\n"
@@ -347,75 +352,75 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr ""
 "eroare în primirea codului de tastã(keycode) pentru codul de scan(scancode) "
 "0x%x\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr ""
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr ""
 "eroare în primirea codului de tastã(keycode) pentru codul de scan(scancode) "
 "0x%x\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "se presupune iso-8859-1 %s\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "se presupune iso-8859-15 %s\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "se presupune iso-8859-2 %s\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "se presupune iso-8859-3 %s\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "se presupune iso-8859-4 %s\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "keysym '%s' necunoscut\n"
@@ -464,12 +469,12 @@ msgstr ""
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr ""
@@ -479,7 +484,7 @@ msgstr ""
 msgid "too many compose definitions"
 msgstr "nr max de definiþii compuse: %d\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -490,21 +495,21 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "nr max de definiþii compuse: %d\n"
 msgstr[1] "nr max de definiþii compuse: %d\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "nr max de definiþii compuse: %d\n"
@@ -574,7 +579,7 @@ msgstr ""
 "\n"
 "S-au recunoscut numele modificatorilor ºi numerele lor de coloane:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -599,70 +604,65 @@ msgid ""
 "  -V --version       print version number\n"
 msgstr ""
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s din %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
 "    (perhaps you want to do `kbd_mode -a'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
 "    (perhaps you want to do `kbd_mode -u'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, fuzzy, c-format
 msgid "Cannot find %s\n"
 msgstr "Nu se poate gãsi fontul %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, fuzzy, c-format
 msgid "cannot open file %s\n"
 msgstr "Nu se poate deschide fiºierul de font %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, fuzzy, c-format
 msgid ""
 "Usage:\n"
 "\t%s [-C console] [-o map.orig]\n"
 msgstr "folosire: %s [-v] [-o map.orig] fiºier-mapare\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Linie de intrare(input) greºitã: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Numãrul reprezentãrii(glyph) (0x%x) mai mare decât fontul\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Sfârºit de interval eronat (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Interval Unicode greºit corespunzãtor intervalului de poziþie font 0x"
 "%x-0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -671,22 +671,22 @@ msgstr ""
 "%s: Intervalul Unicode U+%x-U+%x nu are aceeaºi mãrime ca intervalul de "
 "poziþie al fontului 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: gunoiul(junk) de la sfârºit (%s) ignorat\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Se încarcã maparea unicode din fiºierul %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Avertisment: linie prea lungã\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -695,85 +695,85 @@ msgstr ""
 "%s: nu s-a încãrcat unimap-ul vid\n"
 "(dacã inistaþi: folosiþi opþiunea -f pentru suprascriere(override))\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "intrare"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "intrãri"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "S-a salvat maparea unicode în `%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "S-a adãugat(appended) maparea Unicode\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "folosire: %s [-v] [-o map.orig] fiºier-mapare\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: nu se poate deschide fiºierul de mapare _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Nu se poate gãsi starea(stat) fiºierului de mapare"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Se încarcã maparea de ecran binarã direct-la-font din fiºierul %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Eroare în citirea mapãrii din fiºierul `%s'\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Se încarcã maparea de ecran binarã unicode din fiºierul %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Se încarcã maparea de ecran simbolicã din fiºierul %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Eroare in analiza(parsing) mapãrii simbolice din `%s', linia `%d'\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Eroare în scrierea mapãrii în fiºier\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Nu se poate citi maparea consolei\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "S-a salvat maparea ecranului în `%s'\n"
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -789,11 +789,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr ""
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, fuzzy, c-format
 msgid "%s: Illegal vt number"
 msgstr "openvt: %s: numãr vt ilegal\n"
@@ -842,96 +842,96 @@ msgstr "openvt: se foloseºte VT %s\n"
 msgid "Cannot open %s read/write"
 msgstr "openvt: Nu se poate deschide %s citire/scriere (%s)\n"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr ""
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr ""
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, fuzzy, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "%s:nu se poate derepartiza(deallocate) consola %d\n"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: tabel scurt ucs2 unicode\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: tabel scurt utf8 unicode\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: utf8 eronat\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: eroare utf8 necunoscutã\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: tabel scurt unicode\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Eroare în citirea fontului de intrare(input)"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Apelare greºitã a readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s:Mod fiºier psf nesuportat (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s:Versiune fiºier psf nesuportatã (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: intrare(input) zero pentru mãrime(length)?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: intrare(input) mãrime caracter zero?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Fiºier intrare(input): mãrime intrare(input) eronatã (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Fiºier intrare(input): gunoi(garbage) la sfârºit\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: unicode ilegal %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Nu se poate scrie header-ul fiºierului de font"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Nu se poate scrie fiºierul de font"
@@ -1017,31 +1017,41 @@ msgstr "%s: fiºier psf cu numãr magic necunoscut\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: fontul de intrare(input) nu are un index\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: nu se poate gãsi fiºierul de moduri video %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: nu se poate gãsi fiºierul de moduri video %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Numãr de linii invalid\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Mod vechi: %dx%d  Mod nou: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "Vechi #liniiscan: %d  Nou #liniiscan: %d  Înãlþime caracter: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: comanda `%s' a eºuat\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1049,7 +1059,7 @@ msgstr ""
 "resizecons: nu uitaþi sã schimbaþi TERM (poate în con%dx%d sau în linux-%dx"
 "%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1063,41 +1073,41 @@ msgstr ""
 "sau: resizecons -lines RÂDURI, cu RÂNDURI unul din numerele 25, 28, 30, 34,\n"
 "36, 40, 44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: nu se pot primi(get) permisiile I/O.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "folosire: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "Eroare în citirea %s\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "nu s-a putut citi %s, ºi nu se poate face dump ioctl\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "nu s-a putut citi %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Ciudat ... ecranul este ºi %dx%d ºi %dx%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Eroare în scrierea dump-ului de ecran\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1153,12 +1163,12 @@ msgstr ""
 "    -V\t\tAfiºeazã versiunea ºi iese.\n"
 "Fiºierele sunt încãrcate din directorul curent sau din /usr/lib/kbd/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: prea multe fiºiere de intrare(input)\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1167,126 +1177,126 @@ msgstr ""
 "setfont: nu se poate reveni(restore) ºi din caracterul ROM ºi din fiºier. "
 "Font neschimbat.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Înãlþime de caracter greºitã: %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Lãþime de caracter greºitã: %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: poziþia font 32 este nonblank\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: a fost ºters(wiped)\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: fundalul va arãta nostim\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Se încarcã %d-char fontul %dx%d din fiºierul %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Se încarcã %d-char fontul %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Se încarcã %d-char fontul %dx%d(%d) din fiºierul %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Se încarcã %d-char fontul %dx%d(%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: bug în do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Se încarcã tabela de mapare Unicode...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Nu se poate deschide fiºierul de font %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Când se încarcã mai multe fonturi, toate trebuie sã fie fonturi psf. - %s nu "
 "este\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "S-a citit %d-char fontul %dx%d din fiºierul %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
 "Când se încarcã mai multe fonturi, toate trebuie sã aibã aceeaºi înãlþime\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "Când se încarcã mai multe fonturi, toate trebuie sã aibã aceeaºi lãþime\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Nu se poate gãsi fontul implicit\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Nu se poate gãsi fontul %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Se citeºte fiºierul de font %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Nu existã marcaj_linie_nouã(newline) final în fiºierul combinat\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Prea multe fiºiere de combinat\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - un font din restorefont? Se foloseºte prima jumãtate.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Mãrime fiºier intrare(input) invalidã\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1295,23 +1305,23 @@ msgstr ""
 "Acest fiºier conþine 3 fonturi: 8x8, 8x14 ºi 8x16. Vã rugãm indicaþi\n"
 "folosind o opþiune -8 or -14 or -16 pentru a-l selecta pe cel dorit.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Aþi cerut o mãrime de font %d, dar doar 8, 14, 16 sunt posibile aici.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Nu am gãsit nimic de salvat\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "S-a salvat fiºierul %d-char fontul %dx%d în %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1322,19 +1332,19 @@ msgstr ""
 " (unde scancode este fie xx sau e0xx, dat în hexazecimal,\n"
 " ºi keycode este dat în zecimal)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "numãr par de argumente aºteptat"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "eroare în citirea codului de scan(scancode)"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "cod în afara limitelor(bounds)"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "eroare în setarea scancode %x în keycode %d\n"
@@ -1515,12 +1525,12 @@ msgstr "stare veche:    "
 msgid "new state:    "
 msgstr "stare nouã:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "folosire: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1540,39 +1550,39 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr ""
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, fuzzy, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "%s: %s: Avertisment: linie prea lungã\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "eroare în restaurarea(restore) tabelei de traduceri originale\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "eroare în restaurarea unimap-ului original\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "nu se poate schimba tabela de traduceri\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1609,16 +1619,16 @@ msgid ""
 "\n"
 msgstr "Se încarcã %d-char fontul %dx%d\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?NECUNOSCUT?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "modul kb a fost %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1627,12 +1637,12 @@ msgstr ""
 "[ Dacã încercaþi asta sub X, s-ar putea sã nu funcþioneze\n"
 "atâta timp cât ºi serverul X citeºte /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "s-a primit semnal %d, se face curãþenie...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1689,29 +1699,29 @@ msgstr "apãsare"
 msgid "keycode %3d %s\n"
 msgstr "cod tastã %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 #, fuzzy
 msgid "usage: totextmode\n"
 msgstr "folosire: getkeycodes\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1720,7 +1730,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1741,16 +1751,16 @@ msgstr ""
 "argument necunoscut: _%s_\n"
 "\n"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "%s: VT 1 este consola ºi nu poate fi dealocatã\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,5 +1,5 @@
-# Mesajele în limba românã pentru pachetul kbd.
-# Acest fiºier este distribuit sub aceeaºi licenşã ca pachetul kbd.
+# Mesajele Ã®n limba romÃ¢nÄƒ pentru pachetul kbd.
+# Acest fiÅŸier este distribuit sub aceeaÅŸi licenÅ£Äƒ ca pachetul kbd.
 # Eugen Hoanca <eugenh@urban-grafx.ro>, 2003.
 #
 msgid ""
@@ -12,7 +12,7 @@ msgstr ""
 "Language-Team: Romanian <translation-team-ro@lists.sourceforge.net>\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ISO-8859-2\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 
@@ -31,23 +31,23 @@ msgstr "folosire: chvt N\n"
 #, fuzzy
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr ""
-"Nu am putut gãsi un descriptor de fiºier care sã se refere la aceastã "
-"consolã\n"
+"Nu am putut gÄƒsi un descriptor de fiÅŸier care sÄƒ se refere la aceastÄƒ "
+"consolÄƒ\n"
 
 #: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
-msgstr "%s: opşiune necunoscutã\n"
+msgstr "%s: opÅ£iune necunoscutÄƒ\n"
 
 #: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
-msgstr "%s: 0: numãr VT ilegal\n"
+msgstr "%s: 0: numÄƒr VT ilegal\n"
 
 #: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
-msgstr "%s: VT 1 este consola ºi nu poate fi dealocatã\n"
+msgstr "%s: VT 1 este consola ÅŸi nu poate fi dealocatÄƒ\n"
 
 #: src/deallocvt.c:57
 #, fuzzy, c-format
@@ -80,20 +80,20 @@ msgid ""
 "\t-c --charset="
 msgstr ""
 "\n"
-"folosire: dumpkeys [opşiuni...]\n"
+"folosire: dumpkeys [opÅ£iuni...]\n"
 "\n"
-"opşiuni valide:\n"
+"opÅ£iuni valide:\n"
 "\n"
-"\t-h --help\t    afiºeazã acest text de ajutor\n"
-"\t-i --short-info\t    afiºeazã informaşii despre driverul de tastaturã\n"
-"\t-l --long-info\t    afiºeazã cele de mai sus ºi simbolurile cunoscute "
+"\t-h --help\t    afiÅŸeazÄƒ acest text de ajutor\n"
+"\t-i --short-info\t    afiÅŸeazÄƒ informaÅ£ii despre driverul de tastaturÄƒ\n"
+"\t-l --long-info\t    afiÅŸeazÄƒ cele de mai sus ÅŸi simbolurile cunoscute "
 "loadkeys\n"
-"\t-n --numeric\t    afiºeazã tabela de taste în notare hexazecimalã\n"
-"\t-f --full-table\t    nu foloseºte notaşii scurte, ci un rând pe cod_tastã\n"
-"\t-1 --separate-lines o linie pe (modificator,cod_tastã) pereche\n"
-"\t   --funcs-only\t    afiºeazã numai ºirurile tastei de funcşii\n"
-"\t   --keys-only\t    afiºeazã numai legãturile(bindings) tastelor\n"
-"\t   --compose-only   afiºeazã doar combinaşiile tastelor compuse\n"
+"\t-n --numeric\t    afiÅŸeazÄƒ tabela de taste Ã®n notare hexazecimalÄƒ\n"
+"\t-f --full-table\t    nu foloseÅŸte notaÅ£ii scurte, ci un rÃ¢nd pe cod_tastÄƒ\n"
+"\t-1 --separate-lines o linie pe (modificator,cod_tastÄƒ) pereche\n"
+"\t   --funcs-only\t    afiÅŸeazÄƒ numai ÅŸirurile tastei de funcÅ£ii\n"
+"\t   --keys-only\t    afiÅŸeazÄƒ numai legÄƒturile(bindings) tastelor\n"
+"\t   --compose-only   afiÅŸeazÄƒ doar combinaÅ£iile tastelor compuse\n"
 "\t-c --charset="
 
 #: src/dumpkeys.c:48
@@ -102,7 +102,7 @@ msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
 "\t\t\t    specified character set\n"
 msgstr ""
-"\t\t\t    interpreteazã codurile de acşiune ale caracterelor ce vor fi "
+"\t\t\t    interpreteazÄƒ codurile de acÅ£iune ale caracterelor ce vor fi "
 "luate\n"
 "\t\t\t    din setul de caractere specificat\n"
 
@@ -117,12 +117,12 @@ msgstr ""
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr ""
-"set de caractere %s necunoscut - se ignorã cererea de set de caractere\n"
+"set de caractere %s necunoscut - se ignorÄƒ cererea de set de caractere\n"
 
 #: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
-msgstr "%s: eroare în setarea modului tastaturii\n"
+msgstr "%s: eroare Ã®n setarea modului tastaturii\n"
 
 #: src/dumpkeys.c:177
 #, c-format
@@ -132,7 +132,7 @@ msgid ""
 "\n"
 msgstr ""
 "Simboluri recunoscute de %s:\n"
-"(valoare numericã, simbol)\n"
+"(valoare numericÄƒ, simbol)\n"
 "\n"
 
 #: src/fgconsole.c:20
@@ -193,7 +193,7 @@ msgstr ""
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
-"eroare în primirea codului de tastã(keycode) pentru codul de scan(scancode) "
+"eroare Ã®n primirea codului de tastÄƒ(keycode) pentru codul de scan(scancode) "
 "0x%x\n"
 
 #: src/getunimap.c:32
@@ -236,37 +236,37 @@ msgstr "folosire: kbd_mode [-a|-u|-k|-s]\n"
 #: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
-msgstr "Tastatura este în mod brut (scancode)\n"
+msgstr "Tastatura este Ã®n mod brut (scancode)\n"
 
 #: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
-msgstr "Tastatura este în mod mediu-brut (keycode)\n"
+msgstr "Tastatura este Ã®n mod mediu-brut (keycode)\n"
 
 #: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
-msgstr "Tastatura este în modul implicit (ASCII)\n"
+msgstr "Tastatura este Ã®n modul implicit (ASCII)\n"
 
 #: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
-msgstr "Tastatura este în modul Unicode (UTF-8)\n"
+msgstr "Tastatura este Ã®n modul Unicode (UTF-8)\n"
 
 #: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
-msgstr "Tastatura este într-un mod necunoscut\n"
+msgstr "Tastatura este Ã®ntr-un mod necunoscut\n"
 
 #: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
-msgstr "Rata de Tipãrire(Typematic) setatã la %.1f cps (întârziere = %d ms)\n"
+msgstr "Rata de TipÄƒrire(Typematic) setatÄƒ la %.1f cps (Ã®ntÃ¢rziere = %d ms)\n"
 
 #: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
-msgstr "Folosire: kbdrate [-V] [-s] [-r ratã] [-d întârziere]\n"
+msgstr "Folosire: kbdrate [-V] [-s] [-r ratÄƒ] [-d Ã®ntÃ¢rziere]\n"
 
 #: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
@@ -275,7 +275,7 @@ msgstr "Nu se poate deschide /dev/port"
 #: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
-msgstr "bug: getfont apelat cu numãr(count)<256\n"
+msgstr "bug: getfont apelat cu numÄƒr(count)<256\n"
 
 #: src/kdfontop.c:102
 #, c-format
@@ -285,7 +285,7 @@ msgstr ""
 #: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
-msgstr "%s: memorie plinã\n"
+msgstr "%s: memorie plinÄƒ\n"
 
 #: src/kdmapop.c:162
 #, c-format
@@ -308,8 +308,8 @@ msgstr "nu s-a putut citi %s\n"
 #, fuzzy, c-format
 msgid "Couldn't get a file descriptor referring to the console\n"
 msgstr ""
-"Nu am putut gãsi un descriptor de fiºier care sã se refere la aceastã "
-"consolã\n"
+"Nu am putut gÄƒsi un descriptor de fiÅŸier care sÄƒ se refere la aceastÄƒ "
+"consolÄƒ\n"
 
 #: src/libcommon/version.c:29
 #, c-format
@@ -320,7 +320,7 @@ msgstr "%s din %s\n"
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
-msgstr "%s: memorie plinã\n"
+msgstr "%s: memorie plinÄƒ\n"
 
 #: src/libkeymap/common.c:141
 #, c-format
@@ -330,7 +330,7 @@ msgstr ""
 #: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
-msgstr "Eroare în scrierea mapãrii în fiºier\n"
+msgstr "Eroare Ã®n scrierea mapÄƒrii Ã®n fiÅŸier\n"
 
 #: src/libkeymap/dump.c:545
 #, c-format
@@ -340,7 +340,7 @@ msgstr "imposibil: non meta?\n"
 #: src/libkeymap/kernel.c:32
 #, fuzzy, c-format
 msgid "KDGKBENT: %s: error at index %d in table %d"
-msgstr "eroare KDGKBENT la indexul %d în tabelul %d: "
+msgstr "eroare KDGKBENT la indexul %d Ã®n tabelul %d: "
 
 #: src/libkeymap/kernel.c:60
 #, c-format
@@ -361,7 +361,7 @@ msgstr ""
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr ""
-"eroare în primirea codului de tastã(keycode) pentru codul de scan(scancode) "
+"eroare Ã®n primirea codului de tastÄƒ(keycode) pentru codul de scan(scancode) "
 "0x%x\n"
 
 #: src/libkeymap/kmap.c:125
@@ -378,7 +378,7 @@ msgstr ""
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr ""
-"eroare în primirea codului de tastã(keycode) pentru codul de scan(scancode) "
+"eroare Ã®n primirea codului de tastÄƒ(keycode) pentru codul de scan(scancode) "
 "0x%x\n"
 
 #: src/libkeymap/kmap.c:239
@@ -438,7 +438,7 @@ msgstr ""
 #: src/libkeymap/loadkeys.c:58
 #, fuzzy, c-format
 msgid "keycode %d, table %d = %d%s"
-msgstr "cod tastã %3d %s\n"
+msgstr "cod tastÄƒ %3d %s\n"
 
 #: src/libkeymap/loadkeys.c:59
 msgid "    FAILED"
@@ -447,7 +447,7 @@ msgstr ""
 #: src/libkeymap/loadkeys.c:62
 #, fuzzy, c-format
 msgid "failed to bind key %d to value %d"
-msgstr "eroare în setarea scancode %x în keycode %d\n"
+msgstr "eroare Ã®n setarea scancode %x Ã®n keycode %d\n"
 
 #: src/libkeymap/loadkeys.c:72
 #, c-format
@@ -482,7 +482,7 @@ msgstr ""
 #: src/libkeymap/loadkeys.c:192
 #, fuzzy
 msgid "too many compose definitions"
-msgstr "nr max de definişii compuse: %d\n"
+msgstr "nr max de definiÅ£ii compuse: %d\n"
 
 #: src/libkeymap/loadkeys.c:254
 #, c-format
@@ -506,13 +506,13 @@ msgstr[1] ""
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
-msgstr[0] "nr max de definişii compuse: %d\n"
-msgstr[1] "nr max de definişii compuse: %d\n"
+msgstr[0] "nr max de definiÅ£ii compuse: %d\n"
+msgstr[1] "nr max de definiÅ£ii compuse: %d\n"
 
 #: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
-msgstr "nr max de definişii compuse: %d\n"
+msgstr "nr max de definiÅ£ii compuse: %d\n"
 
 #: src/libkeymap/summary.c:95
 #, c-format
@@ -522,12 +522,12 @@ msgstr "domeniu cod de taste suportat de kernel:           1 - %d\n"
 #: src/libkeymap/summary.c:97
 #, c-format
 msgid "max number of actions bindable to a key:         %d\n"
-msgstr "numãr maxim de acşiuni legate(bindable) de o tastã:         %d\n"
+msgstr "numÄƒr maxim de acÅ£iuni legate(bindable) de o tastÄƒ:         %d\n"
 
 #: src/libkeymap/summary.c:99
 #, fuzzy, c-format
 msgid "number of keymaps in actual use:                 %u\n"
-msgstr "numãr de mapãri de taste în folosire actualã:                 %d\n"
+msgstr "numÄƒr de mapÄƒri de taste Ã®n folosire actualÄƒ:                 %d\n"
 
 #: src/libkeymap/summary.c:102
 #, fuzzy, c-format
@@ -537,22 +537,22 @@ msgstr "din care %d alocate dinamic\n"
 #: src/libkeymap/summary.c:105
 #, c-format
 msgid "ranges of action codes supported by kernel:\n"
-msgstr "interval de coduri de acşiune suportat de kernel:\n"
+msgstr "interval de coduri de acÅ£iune suportat de kernel:\n"
 
 #: src/libkeymap/summary.c:111
 #, c-format
 msgid "number of function keys supported by kernel: %d\n"
-msgstr "numãr taste de funcşii suportat de kernel: %d.\n"
+msgstr "numÄƒr taste de funcÅ£ii suportat de kernel: %d.\n"
 
 #: src/libkeymap/summary.c:113
 #, c-format
 msgid "max nr of compose definitions: %d\n"
-msgstr "nr max de definişii compuse: %d\n"
+msgstr "nr max de definiÅ£ii compuse: %d\n"
 
 #: src/libkeymap/summary.c:115
 #, fuzzy, c-format
 msgid "nr of compose definitions in actual use: %u\n"
-msgstr "nr de definişii compuse actualmente în folosire: %d\n"
+msgstr "nr de definiÅ£ii compuse actualmente Ã®n folosire: %d\n"
 
 #: src/libkeymap/summary.c:139
 #, c-format
@@ -562,7 +562,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Urmãtoarele sinonime sunt recunoscute:\n"
+"UrmÄƒtoarele sinonime sunt recunoscute:\n"
 "\n"
 
 #: src/libkeymap/summary.c:142
@@ -577,7 +577,7 @@ msgid ""
 "Recognized modifier names and their column numbers:\n"
 msgstr ""
 "\n"
-"S-au recunoscut numele modificatorilor ºi numerele lor de coloane:\n"
+"S-au recunoscut numele modificatorilor ÅŸi numerele lor de coloane:\n"
 
 #: src/loadkeys.c:32
 #, c-format
@@ -626,40 +626,40 @@ msgstr ""
 #: src/loadkeys.c:217
 #, fuzzy, c-format
 msgid "Cannot find %s\n"
-msgstr "Nu se poate gãsi fontul %s\n"
+msgstr "Nu se poate gÄƒsi fontul %s\n"
 
 #: src/loadkeys.c:238
 #, fuzzy, c-format
 msgid "cannot open file %s\n"
-msgstr "Nu se poate deschide fiºierul de font %s\n"
+msgstr "Nu se poate deschide fiÅŸierul de font %s\n"
 
 #: src/loadunimap.c:45
 #, fuzzy, c-format
 msgid ""
 "Usage:\n"
 "\t%s [-C console] [-o map.orig]\n"
-msgstr "folosire: %s [-v] [-o map.orig] fiºier-mapare\n"
+msgstr "folosire: %s [-v] [-o map.orig] fiÅŸier-mapare\n"
 
 #: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
-msgstr "Linie de intrare(input) greºitã: %s\n"
+msgstr "Linie de intrare(input) greÅŸitÄƒ: %s\n"
 
 #: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
-msgstr "%s: Numãrul reprezentãrii(glyph) (0x%x) mai mare decât fontul\n"
+msgstr "%s: NumÄƒrul reprezentÄƒrii(glyph) (0x%x) mai mare decÃ¢t fontul\n"
 
 #: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
-msgstr "%s: Sfârºit de interval eronat (0x%x)\n"
+msgstr "%s: SfÃ¢rÅŸit de interval eronat (0x%x)\n"
 
 #: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
-"%s: Interval Unicode greºit corespunzãtor intervalului de pozişie font 0x"
+"%s: Interval Unicode greÅŸit corespunzÄƒtor intervalului de poziÅ£ie font 0x"
 "%x-0x%x\n"
 
 #: src/loadunimap.c:244 src/psfxtable.c:187
@@ -668,23 +668,23 @@ msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
 "%x-0x%x\n"
 msgstr ""
-"%s: Intervalul Unicode U+%x-U+%x nu are aceeaºi mãrime ca intervalul de "
-"pozişie al fontului 0x%x-0x%x\n"
+"%s: Intervalul Unicode U+%x-U+%x nu are aceeaÅŸi mÄƒrime ca intervalul de "
+"poziÅ£ie al fontului 0x%x-0x%x\n"
 
 #: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
-msgstr "%s: gunoiul(junk) de la sfârºit (%s) ignorat\n"
+msgstr "%s: gunoiul(junk) de la sfÃ¢rÅŸit (%s) ignorat\n"
 
 #: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
-msgstr "Se încarcã maparea unicode din fiºierul %s\n"
+msgstr "Se Ã®ncarcÄƒ maparea unicode din fiÅŸierul %s\n"
 
 #: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
-msgstr "%s: %s: Avertisment: linie prea lungã\n"
+msgstr "%s: %s: Avertisment: linie prea lungÄƒ\n"
 
 #: src/loadunimap.c:303
 #, c-format
@@ -692,8 +692,8 @@ msgid ""
 "%s: not loading empty unimap\n"
 "(if you insist: use option -f to override)\n"
 msgstr ""
-"%s: nu s-a încãrcat unimap-ul vid\n"
-"(dacã inistaşi: folosişi opşiunea -f pentru suprascriere(override))\n"
+"%s: nu s-a Ã®ncÄƒrcat unimap-ul vid\n"
+"(dacÄƒ inistaÅ£i: folosiÅ£i opÅ£iunea -f pentru suprascriere(override))\n"
 
 #: src/loadunimap.c:323
 msgid "entry"
@@ -701,62 +701,62 @@ msgstr "intrare"
 
 #: src/loadunimap.c:323
 msgid "entries"
-msgstr "intrãri"
+msgstr "intrÄƒri"
 
 #: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
-msgstr "S-a salvat maparea unicode în `%s'\n"
+msgstr "S-a salvat maparea unicode Ã®n `%s'\n"
 
 #: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
-msgstr "S-a adãugat(appended) maparea Unicode\n"
+msgstr "S-a adÄƒugat(appended) maparea Unicode\n"
 
 #: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
-msgstr "folosire: %s [-v] [-o map.orig] fiºier-mapare\n"
+msgstr "folosire: %s [-v] [-o map.orig] fiÅŸier-mapare\n"
 
 #: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
-msgstr "mapscrn: nu se poate deschide fiºierul de mapare _%s_\n"
+msgstr "mapscrn: nu se poate deschide fiÅŸierul de mapare _%s_\n"
 
 #: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
-msgstr "Nu se poate gãsi starea(stat) fiºierului de mapare"
+msgstr "Nu se poate gÄƒsi starea(stat) fiÅŸierului de mapare"
 
 #: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
-msgstr "Se încarcã maparea de ecran binarã direct-la-font din fiºierul %s\n"
+msgstr "Se Ã®ncarcÄƒ maparea de ecran binarÄƒ direct-la-font din fiÅŸierul %s\n"
 
 #: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
-msgstr "Eroare în citirea mapãrii din fiºierul `%s'\n"
+msgstr "Eroare Ã®n citirea mapÄƒrii din fiÅŸierul `%s'\n"
 
 #: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
-msgstr "Se încarcã maparea de ecran binarã unicode din fiºierul %s\n"
+msgstr "Se Ã®ncarcÄƒ maparea de ecran binarÄƒ unicode din fiÅŸierul %s\n"
 
 #: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
-msgstr "Se încarcã maparea de ecran simbolicã din fiºierul %s\n"
+msgstr "Se Ã®ncarcÄƒ maparea de ecran simbolicÄƒ din fiÅŸierul %s\n"
 
 #: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
-msgstr "Eroare in analiza(parsing) mapãrii simbolice din `%s', linia `%d'\n"
+msgstr "Eroare in analiza(parsing) mapÄƒrii simbolice din `%s', linia `%d'\n"
 
 #: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
-msgstr "Eroare în scrierea mapãrii în fiºier\n"
+msgstr "Eroare Ã®n scrierea mapÄƒrii Ã®n fiÅŸier\n"
 
 #: src/mapscrn.c:296
 #, c-format
@@ -766,7 +766,7 @@ msgstr "Nu se poate citi maparea consolei\n"
 #: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
-msgstr "S-a salvat maparea ecranului în `%s'\n"
+msgstr "S-a salvat maparea ecranului Ã®n `%s'\n"
 
 #: src/openvt.c:48
 #, c-format
@@ -796,7 +796,7 @@ msgstr ""
 #: src/openvt.c:209
 #, fuzzy, c-format
 msgid "%s: Illegal vt number"
-msgstr "openvt: %s: numãr vt ilegal\n"
+msgstr "openvt: %s: numÄƒr vt ilegal\n"
 
 #: src/openvt.c:236
 #, fuzzy
@@ -806,17 +806,17 @@ msgstr "openvt: doar root-ul poate folosi marcajul(flag) -u.\n"
 #: src/openvt.c:265
 #, fuzzy
 msgid "Cannot find a free vt"
-msgstr "openvt: nu pot gãsi un vt liber\n"
+msgstr "openvt: nu pot gÄƒsi un vt liber\n"
 
 #: src/openvt.c:269
 #, fuzzy, c-format
 msgid "Cannot check whether vt %d is free; use `%s -f' to force."
-msgstr "openvt: nu pot verifica dacã vt %d este liber\n"
+msgstr "openvt: nu pot verifica dacÄƒ vt %d este liber\n"
 
 #: src/openvt.c:273
 #, fuzzy, c-format
 msgid "vt %d is in use; command aborted; use `%s -f' to force."
-msgstr "openvt: vt %d este în uz; se renunşã la comandã\n"
+msgstr "openvt: vt %d este Ã®n uz; se renunÅ£Äƒ la comandÄƒ\n"
 
 #: src/openvt.c:283
 msgid "Unable to find command."
@@ -825,7 +825,7 @@ msgstr ""
 #: src/openvt.c:315
 #, fuzzy
 msgid "Unable to set new session"
-msgstr "openvt: nu se poate seta sesiune nouã (%s)\n"
+msgstr "openvt: nu se poate seta sesiune nouÄƒ (%s)\n"
 
 #: src/openvt.c:339
 #, fuzzy, c-format
@@ -835,7 +835,7 @@ msgstr "openvt: Nu se poate deschide %s: %s\n"
 #: src/openvt.c:343
 #, fuzzy, c-format
 msgid "Using VT %s"
-msgstr "openvt: se foloseºte VT %s\n"
+msgstr "openvt: se foloseÅŸte VT %s\n"
 
 #: src/openvt.c:349
 #, fuzzy, c-format
@@ -874,7 +874,7 @@ msgstr "%s: utf8 eronat\n"
 #: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
-msgstr "%s: eroare utf8 necunoscutã\n"
+msgstr "%s: eroare utf8 necunoscutÄƒ\n"
 
 #: src/psffontop.c:135
 #, c-format
@@ -884,42 +884,42 @@ msgstr "%s: tabel scurt unicode\n"
 #: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
-msgstr "%s: Eroare în citirea fontului de intrare(input)"
+msgstr "%s: Eroare Ã®n citirea fontului de intrare(input)"
 
 #: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
-msgstr "%s: Apelare greºitã a readpsffont\n"
+msgstr "%s: Apelare greÅŸitÄƒ a readpsffont\n"
 
 #: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
-msgstr "%s:Mod fiºier psf nesuportat (%d)\n"
+msgstr "%s:Mod fiÅŸier psf nesuportat (%d)\n"
 
 #: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
-msgstr "%s:Versiune fiºier psf nesuportatã (%d)\n"
+msgstr "%s:Versiune fiÅŸier psf nesuportatÄƒ (%d)\n"
 
 #: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
-msgstr "%s: intrare(input) zero pentru mãrime(length)?\n"
+msgstr "%s: intrare(input) zero pentru mÄƒrime(length)?\n"
 
 #: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
-msgstr "%s: intrare(input) mãrime caracter zero?\n"
+msgstr "%s: intrare(input) mÄƒrime caracter zero?\n"
 
 #: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
-msgstr "%s: Fiºier intrare(input): mãrime intrare(input) eronatã (%d)\n"
+msgstr "%s: FiÅŸier intrare(input): mÄƒrime intrare(input) eronatÄƒ (%d)\n"
 
 #: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
-msgstr "%s: Fiºier intrare(input): gunoi(garbage) la sfârºit\n"
+msgstr "%s: FiÅŸier intrare(input): gunoi(garbage) la sfÃ¢rÅŸit\n"
 
 #: src/psffontop.c:360
 #, c-format
@@ -929,33 +929,33 @@ msgstr "appendunicode: unicode ilegal %u\n"
 #: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
-msgstr "Nu se poate scrie header-ul fiºierului de font"
+msgstr "Nu se poate scrie header-ul fiÅŸierului de font"
 
 #: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
-msgstr "Nu se poate scrie fiºierul de font"
+msgstr "Nu se poate scrie fiÅŸierul de font"
 
 #: src/psfxtable.c:114
 #, c-format
 msgid "%s: Warning: line too long\n"
-msgstr "%s: Avertisment: linie prea lungã\n"
+msgstr "%s: Avertisment: linie prea lungÄƒ\n"
 
 #: src/psfxtable.c:128 src/psfxtable.c:138
 #, c-format
 msgid "%s: Bad input line: %s\n"
-msgstr "%s: Linie de intrare(input) greºitã: %s\n"
+msgstr "%s: Linie de intrare(input) greÅŸitÄƒ: %s\n"
 
 #: src/psfxtable.c:147
 #, c-format
 msgid "%s: Glyph number (0x%lx) past end of font\n"
 msgstr ""
-"%s: Numãrul reprezentãrii(glyph) (0x%lx) a depãºit sfârºitul fontului\n"
+"%s: NumÄƒrul reprezentÄƒrii(glyph) (0x%lx) a depÄƒÅŸit sfÃ¢rÅŸitul fontului\n"
 
 #: src/psfxtable.c:152
 #, c-format
 msgid "%s: Bad end of range (0x%lx)\n"
-msgstr "%s: Sfârºit de domeniu(range) eronat (0x%lx)\n"
+msgstr "%s: SfÃ¢rÅŸit de domeniu(range) eronat (0x%lx)\n"
 
 #: src/psfxtable.c:171
 #, c-format
@@ -963,7 +963,7 @@ msgid ""
 "%s: Corresponding to a range of font positions, there should be a Unicode "
 "range\n"
 msgstr ""
-"%s: Corespunzãtor unui interval de pozişii de fonturi, ar trebui sã fie un "
+"%s: CorespunzÄƒtor unui interval de poziÅ£ii de fonturi, ar trebui sÄƒ fie un "
 "interval (range) Unicode\n"
 
 #: src/psfxtable.c:263
@@ -1005,12 +1005,12 @@ msgstr ""
 #: src/psfxtable.c:364
 #, c-format
 msgid "%s: Bad magic number on %s\n"
-msgstr "%s: Numãr magic greºit în cazul %s\n"
+msgstr "%s: NumÄƒr magic greÅŸit Ã®n cazul %s\n"
 
 #: src/psfxtable.c:383
 #, c-format
 msgid "%s: psf file with unknown magic\n"
-msgstr "%s: fiºier psf cu numãr magic necunoscut\n"
+msgstr "%s: fiÅŸier psf cu numÄƒr magic necunoscut\n"
 
 #: src/psfxtable.c:399
 #, c-format
@@ -1020,7 +1020,7 @@ msgstr "%s: fontul de intrare(input) nu are un index\n"
 #: src/resizecons.c:146
 #, fuzzy, c-format
 msgid "resizecons: invalid columns number %d\n"
-msgstr "resizecons: nu se poate gãsi fiºierul de moduri video %s\n"
+msgstr "resizecons: nu se poate gÄƒsi fiÅŸierul de moduri video %s\n"
 
 #: src/resizecons.c:151
 #, c-format
@@ -1030,11 +1030,11 @@ msgstr ""
 #: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
-msgstr "resizecons: nu se poate gãsi fiºierul de moduri video %s\n"
+msgstr "resizecons: nu se poate gÄƒsi fiÅŸierul de moduri video %s\n"
 
 #: src/resizecons.c:182
 msgid "Invalid number of lines\n"
-msgstr "Numãr de linii invalid\n"
+msgstr "NumÄƒr de linii invalid\n"
 
 #: src/resizecons.c:265
 #, c-format
@@ -1044,19 +1044,19 @@ msgstr "Mod vechi: %dx%d  Mod nou: %dx%d\n"
 #: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
-msgstr "Vechi #liniiscan: %d  Nou #liniiscan: %d  Înãlşime caracter: %d\n"
+msgstr "Vechi #liniiscan: %d  Nou #liniiscan: %d  ÃnÄƒlÅ£ime caracter: %d\n"
 
 #: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
-msgstr "resizecons: comanda `%s' a eºuat\n"
+msgstr "resizecons: comanda `%s' a eÅŸuat\n"
 
 #: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
-"resizecons: nu uitaşi sã schimbaşi TERM (poate în con%dx%d sau în linux-%dx"
+"resizecons: nu uitaÅ£i sÄƒ schimbaÅ£i TERM (poate Ã®n con%dx%d sau Ã®n linux-%dx"
 "%d)\n"
 
 #: src/resizecons.c:378
@@ -1068,9 +1068,9 @@ msgid ""
 "60\n"
 msgstr ""
 "resizecons:\n"
-"apelarea este:  resizecons COLOANExRÂNDURI  sau:  resizecons COLOANEx\n"
-"RÂNDURI\n"
-"sau: resizecons -lines RÂDURI, cu RÂNDURI unul din numerele 25, 28, 30, 34,\n"
+"apelarea este:  resizecons COLOANExRÃ‚NDURI  sau:  resizecons COLOANEx\n"
+"RÃ‚NDURI\n"
+"sau: resizecons -lines RÃ‚DURI, cu RÃ‚NDURI unul din numerele 25, 28, 30, 34,\n"
 "36, 40, 44, 50, 60\n"
 
 #: src/resizecons.c:417
@@ -1086,12 +1086,12 @@ msgstr "folosire: screendump [n]\n"
 #: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
-msgstr "Eroare în citirea %s\n"
+msgstr "Eroare Ã®n citirea %s\n"
 
 #: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
-msgstr "nu s-a putut citi %s, ºi nu se poate face dump ioctl\n"
+msgstr "nu s-a putut citi %s, ÅŸi nu se poate face dump ioctl\n"
 
 #: src/screendump.c:132
 #, c-format
@@ -1101,11 +1101,11 @@ msgstr "nu s-a putut citi %s\n"
 #: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
-msgstr "Ciudat ... ecranul este ºi %dx%d ºi %dx%d ??\n"
+msgstr "Ciudat ... ecranul este ÅŸi %dx%d ÅŸi %dx%d ??\n"
 
 #: src/screendump.c:158
 msgid "Error writing screendump\n"
-msgstr "Eroare în scrierea dump-ului de ecran\n"
+msgstr "Eroare Ã®n scrierea dump-ului de ecran\n"
 
 #: src/setfont.c:77
 #, fuzzy, c-format
@@ -1135,38 +1135,38 @@ msgid ""
 "    -V         Print version and exit.\n"
 "Files are loaded from the current directory or %s/*/.\n"
 msgstr ""
-"Folosire: setfont [opşiuni-scriere] [-<N>] [fontnou..] [-m mapare_consolã] [-"
+"Folosire: setfont [opÅ£iuni-scriere] [-<N>] [fontnou..] [-m mapare_consolÄƒ] [-"
 "u mapare_unicode]\n"
-"  opşiuni-scriere (are loc înainte de încãrcarea fiºierului):\n"
-"    -o  <nume_fiºier>\tScrie fontul curent în <nume_fiºier>\n"
-"    -O  <nume_fiºier>\tScrie fontul curent ºi maparea unicode în "
-"<nume_fiºier>\n"
-"    -om <nume_fiºier>\tScrie maparea curentã a consolei în <nume_fiºier>\n"
-"    -ou <nume_fiºier>\tScrie maparea curentã unicode în <nume_fiºier>\n"
-"Dacã nici un fontnou ºi nici o opşiune-[o|O|om|ou|m|u] nu sunt specificate,\n"
-"va fi încãrcat un font nou:\n"
-"    setfont             Încarcã fontul \"default[.gz]\"\n"
-"    setfont -<N>        Încarcã fontul \"default8x<N>[.gz]\"\n"
-"Opşiunea -<N> selecteazã un font dintr-un cod de paginã care conşine trei "
+"  opÅ£iuni-scriere (are loc Ã®nainte de Ã®ncÄƒrcarea fiÅŸierului):\n"
+"    -o  <nume_fiÅŸier>\tScrie fontul curent Ã®n <nume_fiÅŸier>\n"
+"    -O  <nume_fiÅŸier>\tScrie fontul curent ÅŸi maparea unicode Ã®n "
+"<nume_fiÅŸier>\n"
+"    -om <nume_fiÅŸier>\tScrie maparea curentÄƒ a consolei Ã®n <nume_fiÅŸier>\n"
+"    -ou <nume_fiÅŸier>\tScrie maparea curentÄƒ unicode Ã®n <nume_fiÅŸier>\n"
+"DacÄƒ nici un fontnou ÅŸi nici o opÅ£iune-[o|O|om|ou|m|u] nu sunt specificate,\n"
+"va fi Ã®ncÄƒrcat un font nou:\n"
+"    setfont             ÃncarcÄƒ fontul \"default[.gz]\"\n"
+"    setfont -<N>        ÃncarcÄƒ fontul \"default8x<N>[.gz]\"\n"
+"OpÅ£iunea -<N> selecteazÄƒ un font dintr-un cod de paginÄƒ care conÅ£ine trei "
 "fonturi:\n"
-"    setfont -{8|14|16} codepage.cp[.gz]   Încarcã fontul 8x<N> din codepage."
+"    setfont -{8|14|16} codepage.cp[.gz]   ÃncarcÄƒ fontul 8x<N> din codepage."
 "cp\n"
-"Explicit (cu -m sau -u) sau implicit (în fiºierul de font) mapãrile "
+"Explicit (cu -m sau -u) sau implicit (Ã®n fiÅŸierul de font) mapÄƒrile "
 "furnizate\n"
-"vor fi încãrcate, sau în cazul mapãrilor de consolã, activate.\n"
-"    -h<N>      (fãrã spaşiu) Suprascrie(override) înãlşimea fontului.\n"
-"    -m <fn>    Se încarcã maparea de ecran a consolei.\n"
-"    -u <fn>    Se încarcã maparea fontului unicode.\n"
-"    -m nimic\tSe suprimã încãrcarea ºi activarea unei mapãrii de ecran.\n"
-"    -u nimic\tSe suprimã încãrcarea unei mapãri unicode\n"
+"vor fi Ã®ncÄƒrcate, sau Ã®n cazul mapÄƒrilor de consolÄƒ, activate.\n"
+"    -h<N>      (fÄƒrÄƒ spaÅ£iu) Suprascrie(override) Ã®nÄƒlÅ£imea fontului.\n"
+"    -m <fn>    Se Ã®ncarcÄƒ maparea de ecran a consolei.\n"
+"    -u <fn>    Se Ã®ncarcÄƒ maparea fontului unicode.\n"
+"    -m nimic\tSe suprimÄƒ Ã®ncÄƒrcarea ÅŸi activarea unei mapÄƒrii de ecran.\n"
+"    -u nimic\tSe suprimÄƒ Ã®ncÄƒrcarea unei mapÄƒri unicode\n"
 "    -v\t\tDetaliat.\n"
-"    -V\t\tAfiºeazã versiunea ºi iese.\n"
-"Fiºierele sunt încãrcate din directorul curent sau din /usr/lib/kbd/*/.\n"
+"    -V\t\tAfiÅŸeazÄƒ versiunea ÅŸi iese.\n"
+"FiÅŸierele sunt Ã®ncÄƒrcate din directorul curent sau din /usr/lib/kbd/*/.\n"
 
 #: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
-msgstr "setfont: prea multe fiºiere de intrare(input)\n"
+msgstr "setfont: prea multe fiÅŸiere de intrare(input)\n"
 
 #: src/setfont.c:188
 #, c-format
@@ -1174,127 +1174,127 @@ msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
 "unchanged.\n"
 msgstr ""
-"setfont: nu se poate reveni(restore) ºi din caracterul ROM ºi din fiºier. "
+"setfont: nu se poate reveni(restore) ÅŸi din caracterul ROM ÅŸi din fiÅŸier. "
 "Font neschimbat.\n"
 
 #: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
-msgstr "Înãlşime de caracter greºitã: %d\n"
+msgstr "ÃnÄƒlÅ£ime de caracter greÅŸitÄƒ: %d\n"
 
 #: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
-msgstr "Lãşime de caracter greºitã: %d\n"
+msgstr "LÄƒÅ£ime de caracter greÅŸitÄƒ: %d\n"
 
 #: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
-msgstr "%s: pozişia font 32 este nonblank\n"
+msgstr "%s: poziÅ£ia font 32 este nonblank\n"
 
 #: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
-msgstr "%s: a fost ºters(wiped)\n"
+msgstr "%s: a fost ÅŸters(wiped)\n"
 
 #: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
-msgstr "%s: fundalul va arãta nostim\n"
+msgstr "%s: fundalul va arÄƒta nostim\n"
 
 #: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
-msgstr "Se încarcã %d-char fontul %dx%d din fiºierul %s\n"
+msgstr "Se Ã®ncarcÄƒ %d-char fontul %dx%d din fiÅŸierul %s\n"
 
 #: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
-msgstr "Se încarcã %d-char fontul %dx%d\n"
+msgstr "Se Ã®ncarcÄƒ %d-char fontul %dx%d\n"
 
 #: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
-msgstr "Se încarcã %d-char fontul %dx%d(%d) din fiºierul %s\n"
+msgstr "Se Ã®ncarcÄƒ %d-char fontul %dx%d(%d) din fiÅŸierul %s\n"
 
 #: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
-msgstr "Se încarcã %d-char fontul %dx%d(%d)\n"
+msgstr "Se Ã®ncarcÄƒ %d-char fontul %dx%d(%d)\n"
 
 #: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
-msgstr "%s: bug în do_loadtable\n"
+msgstr "%s: bug Ã®n do_loadtable\n"
 
 #: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
-msgstr "Se încarcã tabela de mapare Unicode...\n"
+msgstr "Se Ã®ncarcÄƒ tabela de mapare Unicode...\n"
 
 #: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
-msgstr "Nu se poate deschide fiºierul de font %s\n"
+msgstr "Nu se poate deschide fiÅŸierul de font %s\n"
 
 #: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
-"Când se încarcã mai multe fonturi, toate trebuie sã fie fonturi psf. - %s nu "
+"CÃ¢nd se Ã®ncarcÄƒ mai multe fonturi, toate trebuie sÄƒ fie fonturi psf. - %s nu "
 "este\n"
 
 #: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
-msgstr "S-a citit %d-char fontul %dx%d din fiºierul %s\n"
+msgstr "S-a citit %d-char fontul %dx%d din fiÅŸierul %s\n"
 
 #: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr ""
-"Când se încarcã mai multe fonturi, toate trebuie sã aibã aceeaºi înãlşime\n"
+"CÃ¢nd se Ã®ncarcÄƒ mai multe fonturi, toate trebuie sÄƒ aibÄƒ aceeaÅŸi Ã®nÄƒlÅ£ime\n"
 
 #: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
-"Când se încarcã mai multe fonturi, toate trebuie sã aibã aceeaºi lãşime\n"
+"CÃ¢nd se Ã®ncarcÄƒ mai multe fonturi, toate trebuie sÄƒ aibÄƒ aceeaÅŸi lÄƒÅ£ime\n"
 
 #: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
-msgstr "Nu se poate gãsi fontul implicit\n"
+msgstr "Nu se poate gÄƒsi fontul implicit\n"
 
 #: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
-msgstr "Nu se poate gãsi fontul %s\n"
+msgstr "Nu se poate gÄƒsi fontul %s\n"
 
 #: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
-msgstr "Se citeºte fiºierul de font %s\n"
+msgstr "Se citeÅŸte fiÅŸierul de font %s\n"
 
 #: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
-msgstr "Nu existã marcaj_linie_nouã(newline) final în fiºierul combinat\n"
+msgstr "Nu existÄƒ marcaj_linie_nouÄƒ(newline) final Ã®n fiÅŸierul combinat\n"
 
 #: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
-msgstr "Prea multe fiºiere de combinat\n"
+msgstr "Prea multe fiÅŸiere de combinat\n"
 
 #: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
-msgstr "Hmm - un font din restorefont? Se foloseºte prima jumãtate.\n"
+msgstr "Hmm - un font din restorefont? Se foloseÅŸte prima jumÄƒtate.\n"
 
 #: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
-msgstr "Mãrime fiºier intrare(input) invalidã\n"
+msgstr "MÄƒrime fiÅŸier intrare(input) invalidÄƒ\n"
 
 #: src/setfont.c:650
 #, c-format
@@ -1302,24 +1302,24 @@ msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
 "using an option -8 or -14 or -16 which one you want loaded.\n"
 msgstr ""
-"Acest fiºier conşine 3 fonturi: 8x8, 8x14 ºi 8x16. Vã rugãm indicaşi\n"
-"folosind o opşiune -8 or -14 or -16 pentru a-l selecta pe cel dorit.\n"
+"Acest fiÅŸier conÅ£ine 3 fonturi: 8x8, 8x14 ÅŸi 8x16. VÄƒ rugÄƒm indicaÅ£i\n"
+"folosind o opÅ£iune -8 or -14 or -16 pentru a-l selecta pe cel dorit.\n"
 
 #: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
-"Aşi cerut o mãrime de font %d, dar doar 8, 14, 16 sunt posibile aici.\n"
+"AÅ£i cerut o mÄƒrime de font %d, dar doar 8, 14, 16 sunt posibile aici.\n"
 
 #: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
-msgstr "Nu am gãsit nimic de salvat\n"
+msgstr "Nu am gÄƒsit nimic de salvat\n"
 
 #: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
-msgstr "S-a salvat fiºierul %d-char fontul %dx%d în %s\n"
+msgstr "S-a salvat fiÅŸierul %d-char fontul %dx%d Ã®n %s\n"
 
 #: src/setkeycodes.c:25
 #, c-format
@@ -1329,25 +1329,25 @@ msgid ""
 "  and keycode is given in decimal)\n"
 msgstr ""
 "folosire: setkeycode scancode keycode ...\n"
-" (unde scancode este fie xx sau e0xx, dat în hexazecimal,\n"
-" ºi keycode este dat în zecimal)\n"
+" (unde scancode este fie xx sau e0xx, dat Ã®n hexazecimal,\n"
+" ÅŸi keycode este dat Ã®n zecimal)\n"
 
 #: src/setkeycodes.c:47
 msgid "even number of arguments expected"
-msgstr "numãr par de argumente aºteptat"
+msgstr "numÄƒr par de argumente aÅŸteptat"
 
 #: src/setkeycodes.c:56
 msgid "error reading scancode"
-msgstr "eroare în citirea codului de scan(scancode)"
+msgstr "eroare Ã®n citirea codului de scan(scancode)"
 
 #: src/setkeycodes.c:64
 msgid "code outside bounds"
-msgstr "cod în afara limitelor(bounds)"
+msgstr "cod Ã®n afara limitelor(bounds)"
 
 #: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
-msgstr "eroare în setarea scancode %x în keycode %d\n"
+msgstr "eroare Ã®n setarea scancode %x Ã®n keycode %d\n"
 
 #: src/setleds.c:25
 #, c-format
@@ -1369,14 +1369,14 @@ msgstr ""
 "\tsetleds [-v] [-L] [-D] [-F] [[+|-][ num | caps | scroll %s]]\n"
 "Astfel,\n"
 "\tsetleds +caps -num\n"
-"va seta CapsLock, ºterge NumLock ºi va lãsa ScrollLock neschimbat.\n"
-"Setãrile de dinainte ºi de dupã schimbare(dacã existã) sunt raportate\n"
-"când opşiunea -v este furnizatã sau când nu este cerutã nici o schimbare.\n"
-"În mod normal, setleds influenşeazã setãrile marcajului(flag) vt\n"
-"(ºi acestea sunt de obicei reflectate în leduri).\n"
-"Cu -L, setleds doar va seta ledurile, nechimbând marcajele(flag).\n"
-"Cu -D, setleds seteazã atât marcajele(flags), cât ºi marcajele implicite,\n"
-"pentru ca o resetare ulterioarã nu va schimba marcajele.\n"
+"va seta CapsLock, ÅŸterge NumLock ÅŸi va lÄƒsa ScrollLock neschimbat.\n"
+"SetÄƒrile de dinainte ÅŸi de dupÄƒ schimbare(dacÄƒ existÄƒ) sunt raportate\n"
+"cÃ¢nd opÅ£iunea -v este furnizatÄƒ sau cÃ¢nd nu este cerutÄƒ nici o schimbare.\n"
+"Ãn mod normal, setleds influenÅ£eazÄƒ setÄƒrile marcajului(flag) vt\n"
+"(ÅŸi acestea sunt de obicei reflectate Ã®n leduri).\n"
+"Cu -L, setleds doar va seta ledurile, nechimbÃ¢nd marcajele(flag).\n"
+"Cu -D, setleds seteazÄƒ atÃ¢t marcajele(flags), cÃ¢t ÅŸi marcajele implicite,\n"
+"pentru ca o resetare ulterioarÄƒ nu va schimba marcajele.\n"
 
 #: src/setleds.c:46
 msgid "on "
@@ -1391,7 +1391,7 @@ msgstr "dezactivat(off)"
 msgid ""
 "Error reading current led setting. Maybe stdin is not a VT?: ioctl KDGETLED"
 msgstr ""
-"Eroare în citirea setãrilor curente ale ledului. E posibil ca stdin sã nu "
+"Eroare Ã®n citirea setÄƒrilor curente ale ledului. E posibil ca stdin sÄƒ nu "
 "fie un VT?\n"
 
 #: src/setleds.c:110
@@ -1400,13 +1400,13 @@ msgid ""
 "Error reading current flags setting. Maybe you are not on the console?: "
 "ioctl KDGKBLED"
 msgstr ""
-"Eroare în citirea setãrilor marcajelor(flags) curente. Poate nu sunteşi în "
-"consolã?\n"
+"Eroare Ã®n citirea setÄƒrilor marcajelor(flags) curente. Poate nu sunteÅ£i Ã®n "
+"consolÄƒ?\n"
 
 #: src/setleds.c:129
 #, fuzzy
 msgid "Error reading current led setting from /dev/kbd: ioctl KIOCGLED"
-msgstr "Eroare în citirea setãrii curente a ledului din /dev/kbd.\n"
+msgstr "Eroare Ã®n citirea setÄƒrii curente a ledului din /dev/kbd.\n"
 
 #: src/setleds.c:133
 msgid "KIOCGLED unavailable?\n"
@@ -1415,7 +1415,7 @@ msgstr "KIOCGLED indisponibil?\n"
 #: src/setleds.c:148
 #, fuzzy
 msgid "Error reading current led setting from /dev/kbd: ioctl KIOCSLED"
-msgstr "Eroare în citirea setãrii curente a ledului din /dev/kbd.\n"
+msgstr "Eroare Ã®n citirea setÄƒrii curente a ledului din /dev/kbd.\n"
 
 #: src/setleds.c:152
 msgid "KIOCSLED unavailable?\n"
@@ -1423,7 +1423,7 @@ msgstr "KIOCSLED indisponibil?\n"
 
 #: src/setleds.c:208
 msgid "Error resetting ledmode\n"
-msgstr "Eroare în resetarea modurilor ledului\n"
+msgstr "Eroare Ã®n resetarea modurilor ledului\n"
 
 #: src/setleds.c:216
 #, c-format
@@ -1491,18 +1491,18 @@ msgid ""
 msgstr ""
 "Folosire:\n"
 "\tsetmetamode [ metabit | meta | bit | escprefix | esc | prefix ]\n"
-"Fiecare vt are propria copie a acestui bit. Folosişi\n"
+"Fiecare vt are propria copie a acestui bit. FolosiÅ£i\n"
 "\tsetmetamode [arg] < /dev/ttyn\n"
-"pentru a schimba setãrile altui vt.\n"
-"Setãrile de dinainte ºi de dupã schimbãri sunt raportate.\n"
+"pentru a schimba setÄƒrile altui vt.\n"
+"SetÄƒrile de dinainte ÅŸi de dupÄƒ schimbÄƒri sunt raportate.\n"
 
 #: src/setmetamode.c:40
 msgid "Meta key sets high order bit\n"
-msgstr "Tasta Meta seteazã bitul de ordine înaltã\n"
+msgstr "Tasta Meta seteazÄƒ bitul de ordine Ã®naltÄƒ\n"
 
 #: src/setmetamode.c:43
 msgid "Meta key gives Esc prefix\n"
-msgstr "Tasta Meta furnizeazã prefix Esc\n"
+msgstr "Tasta Meta furnizeazÄƒ prefix Esc\n"
 
 #: src/setmetamode.c:46
 msgid "Strange mode for Meta key?\n"
@@ -1513,7 +1513,7 @@ msgstr "Mod ciudat pentru tasta Meta?\n"
 msgid ""
 "Error reading current setting. Maybe stdin is not a VT?: ioctl KDGKBMETA"
 msgstr ""
-"Eroare în citirea setãrii curente. E posibil ca stdin sã nu fie un VT?\n"
+"Eroare Ã®n citirea setÄƒrii curente. E posibil ca stdin sÄƒ nu fie un VT?\n"
 
 #: src/setmetamode.c:100
 #, c-format
@@ -1523,7 +1523,7 @@ msgstr "stare veche:    "
 #: src/setmetamode.c:105
 #, c-format
 msgid "new state:    "
-msgstr "stare nouã:    "
+msgstr "stare nouÄƒ:    "
 
 #: src/setvesablank.c:30
 #, c-format
@@ -1568,15 +1568,15 @@ msgstr ""
 #: src/setvtrgb.c:90
 #, fuzzy, c-format
 msgid "Error: %s: Line %u is too long.\n"
-msgstr "%s: %s: Avertisment: linie prea lungã\n"
+msgstr "%s: %s: Avertisment: linie prea lungÄƒ\n"
 
 #: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
-msgstr "eroare în restaurarea(restore) tabelei de traduceri originale\n"
+msgstr "eroare Ã®n restaurarea(restore) tabelei de traduceri originale\n"
 
 #: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
-msgstr "eroare în restaurarea unimap-ului original\n"
+msgstr "eroare Ã®n restaurarea unimap-ului original\n"
 
 #: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
@@ -1600,7 +1600,7 @@ msgstr ""
 #: src/showconsolefont.c:170
 #, fuzzy, c-format
 msgid "Character count: %d\n"
-msgstr "Lãşime de caracter greºitã: %d\n"
+msgstr "LÄƒÅ£ime de caracter greÅŸitÄƒ: %d\n"
 
 #: src/showconsolefont.c:171
 #, c-format
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid ""
 "Showing %d-char font\n"
 "\n"
-msgstr "Se încarcã %d-char fontul %dx%d\n"
+msgstr "Se Ã®ncarcÄƒ %d-char fontul %dx%d\n"
 
 #: src/showkey.c:49
 msgid "?UNKNOWN?"
@@ -1634,13 +1634,13 @@ msgid ""
 "[ if you are trying this under X, it might not work\n"
 "since the X server is also reading /dev/console ]\n"
 msgstr ""
-"[ Dacã încercaşi asta sub X, s-ar putea sã nu funcşioneze\n"
-"atâta timp cât ºi serverul X citeºte /dev/console ]\n"
+"[ DacÄƒ Ã®ncercaÅ£i asta sub X, s-ar putea sÄƒ nu funcÅ£ioneze\n"
+"atÃ¢ta timp cÃ¢t ÅŸi serverul X citeÅŸte /dev/console ]\n"
 
 #: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
-msgstr "s-a primit semnal %d, se face curãşenie...\n"
+msgstr "s-a primit semnal %d, se face curÄƒÅ£enie...\n"
 
 #: src/showkey.c:90
 #, fuzzy, c-format
@@ -1659,14 +1659,14 @@ msgid ""
 msgstr ""
 "showkey versiunea %s\n"
 "\n"
-"folosire: showkey [opşiune ...]\n"
+"folosire: showkey [opÅ£iune ...]\n"
 "\n"
-"opşiuni valide:\n"
+"opÅ£iuni valide:\n"
 "\n"
-"\t-h --help\tafiºeazã acest text de ajutor\n"
-"\t-a --ascii\tafiºeazã valorile zecimale/octale/hexazecimale ale tastelor\n"
-"\t-s --scancodes\tafiºeazã doar codurile de scanare brute(raw)\n"
-"\t-k --keycodes\tafiºeazã doar codurile de taste interpretate(implicit)\n"
+"\t-h --help\tafiÅŸeazÄƒ acest text de ajutor\n"
+"\t-a --ascii\tafiÅŸeazÄƒ valorile zecimale/octale/hexazecimale ale tastelor\n"
+"\t-s --scancodes\tafiÅŸeazÄƒ doar codurile de scanare brute(raw)\n"
+"\t-k --keycodes\tafiÅŸeazÄƒ doar codurile de taste interpretate(implicit)\n"
 
 #: src/showkey.c:171
 #, c-format
@@ -1676,15 +1676,15 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Apãsaşi orice taste - Ctrl-D va termina acest program\n"
+"ApÄƒsaÅ£i orice taste - Ctrl-D va termina acest program\n"
 "\n"
 
 #: src/showkey.c:239
 #, c-format
 msgid "press any key (program terminates 10s after last keypress)...\n"
 msgstr ""
-"aspãsaşi orice tastã (programul se terminã la 10s dupã ultima apãsare de "
-"tastã)...\n"
+"aspÄƒsaÅ£i orice tastÄƒ (programul se terminÄƒ la 10s dupÄƒ ultima apÄƒsare de "
+"tastÄƒ)...\n"
 
 #: src/showkey.c:263
 msgid "release"
@@ -1692,12 +1692,12 @@ msgstr "eliberare"
 
 #: src/showkey.c:263
 msgid "press"
-msgstr "apãsare"
+msgstr "apÄƒsare"
 
 #: src/showkey.c:273
 #, c-format
 msgid "keycode %3d %s\n"
-msgstr "cod tastã %3d %s\n"
+msgstr "cod tastÄƒ %3d %s\n"
 
 #: src/totextmode.c:31
 #, fuzzy
@@ -1763,10 +1763,10 @@ msgstr ""
 #: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
-msgstr "%s: VT 1 este consola ºi nu poate fi dealocatã\n"
+msgstr "%s: VT 1 este consola ÅŸi nu poate fi dealocatÄƒ\n"
 
 #~ msgid "        use `openvt -f' to force.\n"
-#~ msgstr "        folosişi `openvt -f' pentru a forşa.\n"
+#~ msgstr "        folosiÅ£i `openvt -f' pentru a forÅ£a.\n"
 
 #~ msgid ""
 #~ "\n"
@@ -1779,45 +1779,45 @@ msgstr "%s: VT 1 este consola ºi nu poate fi dealocatã\n"
 #~ msgstr "openvt: nu se poate derepartiza(deallocate) consola %d\n"
 
 #~ msgid "%s: deallocating all unused consoles failed\n"
-#~ msgstr "%s: dealocarea tuturor consolelor nefolosite a eºuat\n"
+#~ msgstr "%s: dealocarea tuturor consolelor nefolosite a eÅŸuat\n"
 
 #~ msgid "KDGKBENT error at index 0 in table %d: "
 #~ msgstr "eroare KDGKBENT la indexul 0 din tabelul %d: "
 
 #~ msgid "%s: cannot find any keymaps?\n"
-#~ msgstr "%s: nu pot gãsi nici o mapare de taste?\n"
+#~ msgstr "%s: nu pot gÄƒsi nici o mapare de taste?\n"
 
 #~ msgid "%s: plain map not allocated? very strange ...\n"
-#~ msgstr "%s: maparea simplã(plain) nealocatã? foarte ciudat ...\n"
+#~ msgstr "%s: maparea simplÄƒ(plain) nealocatÄƒ? foarte ciudat ...\n"
 
 #~ msgid "# not alt_is_meta: on keymap %d key %d is bound to"
 #~ msgstr ""
-#~ "# diferit de alt_is_meta: în maparea de taste %d tasta %d este legatã de"
+#~ "# diferit de alt_is_meta: Ã®n maparea de taste %d tasta %d este legatÄƒ de"
 
 #~ msgid "KDGKBSENT failed at index %d: "
 #~ msgstr "eroare KDGKBSENT la indexul %d: "
 
 #~ msgid "error executing  %s\n"
-#~ msgstr "eroare în executarea  %s\n"
+#~ msgstr "eroare Ã®n executarea  %s\n"
 
 #~ msgid "kbd_mode: error reading keyboard mode\n"
-#~ msgstr "kbd_mode: eroare în citirea modului tastaturii\n"
+#~ msgstr "kbd_mode: eroare Ã®n citirea modului tastaturii\n"
 
 #~ msgid "plus before %s ignored\n"
-#~ msgstr "plus înainte de %s ignorat\n"
+#~ msgstr "plus Ã®nainte de %s ignorat\n"
 
 #~ msgid "usage: %s [-o map.orig] [map-file]\n"
-#~ msgstr "folosire: %s [-o map.orig] [fiºier-mapare]\n"
+#~ msgstr "folosire: %s [-o map.orig] [fiÅŸier-mapare]\n"
 
 #~ msgid "Error opening /dev/kbd.\n"
-#~ msgstr "Eroare în deschiderea /dev/kbd.\n"
+#~ msgstr "Eroare Ã®n deschiderea /dev/kbd.\n"
 
 #~ msgid "%s: out of memory?\n"
-#~ msgstr "%s: memorie plinã?\n"
+#~ msgstr "%s: memorie plinÄƒ?\n"
 
 #~ msgid ""
 #~ "usage: showconsolefont [-v|-V]\n"
 #~ "(probably after loading a font with `setfont font')\n"
 #~ msgstr ""
 #~ "folosire: showconsolefont [-v|-V]\n"
-#~ "(probabil dupã încãrcarea unui font cu `setfont font')\n"
+#~ "(probabil dupÄƒ Ã®ncÄƒrcarea unui font cu `setfont font')\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-12-27 19:55+0300\n"
 "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -21,45 +21,45 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "Использование: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Не удалось получить файловый дескриптор, указывающий на консоль"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: неизвестный параметр\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: недопустимый номер VT\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 является консолью и не может быть освобождена\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "не удалось освободить консоль %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys, версия %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -98,7 +98,7 @@ msgstr ""
 "\t-d --compose-only   показать только составные комбинации клавиш\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -107,7 +107,7 @@ msgstr ""
 "\t\t\t    считать, что коды действий клавиш заданы\n"
 "\t\t\t    в указанной символьной кодировке\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -116,17 +116,17 @@ msgstr ""
 "\t-v --verbose\n"
 "\t-V --version\t    показать номер версии\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "неизвестная кодировка %s — пропускается запрос кодировки\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: ошибка чтения режима клавиатуры: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -137,7 +137,7 @@ msgstr ""
 "(числовое значение, символ)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -160,41 +160,31 @@ msgstr ""
 "\t-V --version         показать версию программы\n"
 "\t-n --next-available  показать номер следующего незанятого VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Не удалось прочитать VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Не удалось открыть %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Не удалось получить файловый дескриптор, указывающий на консоль\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "Использование: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Простые скан-коды xx (шестн.) и соответствующие коды клавиш (десят.)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr "0 — ошибка; скан-коды 1-88 (0x01-0x58) эквивалентны кодам клавиш\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "скан-коды 1-%d (0x01-0x%02x) эквивалентны кодам клавиш\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -205,14 +195,14 @@ msgstr ""
 "\n"
 "Экранированные скан-коды e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "не удалось найти код клавиши, соответствующий скан-коду 0x%x: ioctl "
 "KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -249,72 +239,72 @@ msgstr "Ошибка: недостаточно аргументов.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Ошибка: нераспознанное действие: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "Использование: kbd_mode [-a|-u|-k|-s] [-C устройство]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Клавиатура находится в режиме без обработки (шлёт скан-коды)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Клавиатура находится в режиме полуобработки (шлёт коды клавиш)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Клавиатура находится в обычном режиме (шлёт ASCII-коды)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Клавиатура находится в режиме Unicode (шлёт коды UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Клавиатура находится в неизвестном режиме\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Скорость ввода равна %.1f знак/сек (задержка = %d мс)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr ""
 "Использование: kbdrate [-V | --version] [-s] [-r скорость] [-d задержка]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Не удалось открыть /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "ошибка: getfont была вызвана с count < 256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "ошибка: getfont, использующему GIO_FONT, требуется buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: нехватка памяти\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "странно... ct изменено с %d на %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -323,21 +313,36 @@ msgstr ""
 "Кажется, что версия ядра старее чем 1.1.92.\n"
 "Таблица отображения Юникода загружена не будет.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Не удалось открыть %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Не удалось получить файловый дескриптор, указывающий на консоль\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s из %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "недостаточно памяти"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "не удалось инициализировать массив: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Ошибка записи карты в файл"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "невозможно: не мета?\n"
@@ -358,71 +363,71 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: Невозможно получить таблицу диакритических знаков"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "не удалось получить раскладку %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "не удалось удалить клавишу %d из таблицы %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key вызвана с некорректным кодом клавиши %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "добавление карты %d противоречит явному указанию в строке keymaps"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "не удалось добавить клавишу %d в таблицу %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "невозможная ошибка в lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "невозможно получить символ по некорректному типу: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "невозможно получить символ с типом %d по некорректному индексу: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "предполагается iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "предполагается iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "предполагается iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "предполагается iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "предполагается iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "неизвестный keysym «%s»\n"
@@ -471,12 +476,12 @@ msgstr "KDSKBENT: %s: не удалось освободить или очист
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: не удалось вернуть первоначальный режим клавиатуры"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "не удалось назначить строку «%s» на функцию %s"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "не удалось очистить строку %s"
@@ -485,7 +490,7 @@ msgstr "не удалось очистить строку %s"
 msgid "too many compose definitions"
 msgstr "слишком много составных определений"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -503,7 +508,7 @@ msgstr[2] ""
 "\n"
 "Изменено %d клавиш"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -511,7 +516,7 @@ msgstr[0] "Изменена %d строка"
 msgstr[1] "Изменены %d строки"
 msgstr[2] "Изменено %d строк"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
@@ -519,7 +524,7 @@ msgstr[0] "Загружено %d составное определение"
 msgstr[1] "Загружено %d составных определения"
 msgstr[2] "Загружено %d составных определений"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Составные определения не изменились)"
 
@@ -589,7 +594,7 @@ msgstr ""
 "\n"
 "Распознанные имена модификаторов и их номера колонок:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -634,17 +639,12 @@ msgstr ""
 "  -v --verbose       сообщить об изменениях\n"
 "  -V --version       показать номер версии\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s из %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: параметры --unicode и --ascii взаимно исключают друг друга\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -654,7 +654,7 @@ msgstr ""
 "консоль\n"
 "    (возможно, вы хотите выполнить «kbd_mode -u»?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -664,17 +664,17 @@ msgstr ""
 "консоль\n"
 "    (возможно, вы хотите выполнить «kbd_mode -u»?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Не удалось найти %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "не удалось открыть файл %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -683,30 +683,30 @@ msgstr ""
 "Использование:\n"
 "\t%s [-C консоль] [-o map.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Некорректная входная строка: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr ""
 "%s: Номер образа символа (0x%x) больше количества знаков в этом шрифте\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Некорректный конец диапазона (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Недопустимый диапазон Юникода, соответствующий диапазону шрифта 0x%x-0x"
 "%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -715,22 +715,22 @@ msgstr ""
 "%s: Диапазон Юникода U+%x-U+%x отличается длиной от диапазона шрифта 0x%x-0x"
 "%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: игнорируется мусор в конце (%s)\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Загружается карта Юникода из файла %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Предупреждение: слишком длинная строка\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -739,87 +739,87 @@ msgstr ""
 "%s: не загружается пустой unimap\n"
 "(если это нужно, укажите параметр -f)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "элемент"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "элементов"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Юникодная карта записана в «%s»\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Юникодная карта добавлена\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "Использование: %s [-v] [-v] [-o map.orig] файл_карты\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: не удалось открыть файл _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Не удалось получить информацию о файле (stat)"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr ""
 "Загружается двоичная экранная карта прямого соответствия шрифтов из файла "
 "%s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Ошибка чтения карты из файла «%s»\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Загружается двоичная юникодная экранная карта из файла %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Загружается символьная экранная карта из файла %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Ошибка при разборе символьной карты из «%s», строка %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Ошибка записи карты в файл\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Не удалось прочитать консольную карту\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Экранная карта записана в «%s»\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -852,11 +852,11 @@ msgstr ""
 "  -h, --help          показать краткую справку.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Не удалось определить владельца текущего tty!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: недопустимый номер vt"
@@ -906,96 +906,96 @@ msgstr "Используется VT %s"
 msgid "Cannot open %s read/write"
 msgstr "Не удалось открыть %s на чтение/запись"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Не удалось активировать vt %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Активация прервана?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Не удалось освободить консоль %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: сокращённая юникодная таблица ucs2\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: сокращённая юникодная таблица utf8\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: некорректный utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: неизвестная ошибка utf8\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: короткая юникодная таблица\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: ошибка чтения входного шрифта"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: некорректный вызов readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: неподдерживаемый режим файла psf (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: неподдерживаемая версия psf (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: входной шрифт имеет нулевую длину?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: входной символ имеет нулевой размер?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: входной файл: некорректная входная длина (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: входной файл: мусор в конце\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: недопустимый юникод %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Не удалось записать заголовок файла шрифта"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Не удалось записать файл шрифта"
@@ -1080,33 +1080,43 @@ msgstr "%s: файл psf с неизвестным опознавательны�
 msgid "%s: input font does not have an index\n"
 msgstr "%s: входной шрифт не имеет индекса\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: не удалось найти файл видеорежима %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: не удалось найти файл видеорежима %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "недопустимое число строк\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Прежний режим: %dx%d Новый режим: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 "Строк развёртки в прежнем режиме: %d Строк развёртки в новом режиме: %d "
 "Высота шрифта: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: команда «%s» завершилась неудачно\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1114,7 +1124,7 @@ msgstr ""
 "resizecons: не забудьте сменить TERM (возможно, на con%dx%d или linux-%dx"
 "%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1127,41 +1137,41 @@ msgstr ""
 "или:\tresizecons -lines СТРОК, где параметр СТРОК может\n"
 "принимать значения: 25, 28, 30, 34, 36, 40, 44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: не удалось получить права на доступ ко вводу-выводу.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "Использование: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Ошибка чтения %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "не удалось прочитать %s и не удалось выполнить ioctl dump\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "не удалось прочитать %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Странно... Экран одновременно и %dx%d, и %dx%d?\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Ошибка записи содержимого экрана\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1216,12 +1226,12 @@ msgstr ""
 "    -V         Показать версию и закончить работу.\n"
 "Файлы загружаются из текущего каталога или из %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: слишком много входных файлов\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1230,124 +1240,124 @@ msgstr ""
 "setfont: не удалось восстановить сразу из символьного ПЗУ и из файла. Шрифт "
 "не изменён.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Некорректная высота символа %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Некорректная ширина символа %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: позиция 32 в шрифте не пробельная\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: стереть его\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: фон будет выглядеть забавно\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Загружается %d-символ шрифта %dx%d из файла %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Загружается %d-символ шрифта %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Загружается %d-символ шрифта %dx%d (%d) из файла %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Загружается %d-символ шрифта %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: ошибка в do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Загружается юникодная таблица отображения...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Не удалось открыть файл шрифта %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "При загрузке нескольких шрифтов все должны быть в формате psf: %s таковым не "
 "является\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Читается %d-символ шрифта %dx%d из файла %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "При загрузке нескольких шрифтов все должны быть одинаковой высоты\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "При загрузке нескольких шрифтов все должны быть одинаковой ширины\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Не удалось найти шрифт по умолчанию\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Не удалось найти шрифт %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Читается файл шрифта %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Отсутствует завершающий символ новой строки в объединённом файле\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Слишком много объединяемых файлов\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Хм. Шрифт из restorefont? Используется первая половина.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Некорректный размер входного файла\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1357,22 +1367,22 @@ msgstr ""
 "Укажите, одним из параметров: -8, -14 или -16,\n"
 "какой именно нужно загрузить.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr "Вы просили шрифт размера %d, но возможны только 8, 14 или 16.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Не найдено что записывать\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Записывается %d-символ шрифта %dx%d файла в %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1383,19 +1393,19 @@ msgstr ""
 "Скан-код следует писать в шестнадцатеричном виде: xx или e0xx,\n"
 "код клавиши — в десятичном.\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "ожидается чётное число аргументов"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "ошибка чтения скан-кода"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "код вне допустимого диапазона"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "не удалось назначить скан-код %x коду клавиши %d: ioctl KDSETKEYCODE"
@@ -1577,12 +1587,12 @@ msgstr "прежнее состояние:   "
 msgid "new state:    "
 msgstr "новое состояние:   "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "Использование: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1617,39 +1627,39 @@ msgstr ""
 "   -V     показать номер версии\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Ошибка: %s: Некорректное значение в поле %u в строке %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Ошибка: %s: недостаточное количество полей в строке %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Ошибка: %s: неожиданный конец строки %u.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Ошибка: %s: строка %u слишком длинна.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "не удалось восстановить исходную таблицу трансляций\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "не удалось восстановить исходную unimap\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "не удалось изменить таблицу трансляций\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1699,16 +1709,16 @@ msgstr ""
 "Отображается %d-символ шрифта\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?НЕИЗВЕСТНО?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "режим kb был %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1717,12 +1727,12 @@ msgstr ""
 "[ если вы пытаетесь проделать это под X-ами, то, возможно,\n"
 "это не сработает, так как X-сервер тоже читает /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "пойман сигнал %d, очистка...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1782,11 +1792,11 @@ msgstr "нажата"
 msgid "keycode %3d %s\n"
 msgstr "код клавиши %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "Использование: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1796,17 +1806,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Теперь вывод на консоль полностью заблокирован %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "Блокировка %s установлена %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 "Используйте Alt-функциональные клавиши для перехода в другие виртуальные "
@@ -1817,7 +1827,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr "Дополнительная информация доступна по команде «%s --help».\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1844,16 +1854,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "неопознанный пользователь"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "стандартный ввод не является устройством tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Данное устройство tty (%s) не является виртуальной консолью.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Экран консоли не может быть быть заблокирован целиком.\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-12-27 23:53+0100\n"
 "Last-Translator: Göran Uddeborg <goeran@uddeborg.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -22,45 +22,45 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "användning: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Kunde inte få en filidentifierare för konsolen"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: okänd flagga\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: ogiltigt VT-nummer\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 är konsolen och kan inte avallokeras\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "kunde inte avallokera konsol %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys version %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -97,7 +97,7 @@ msgstr ""
 "\t-d --compose-only   visa bara kompositionstangentkombinationer\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -106,7 +106,7 @@ msgstr ""
 "\t\t\t    tolka teckenåtgärdsskoder som om de är från den\n"
 "\t\t\t    angivna teckenuppsättningen\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -115,17 +115,17 @@ msgstr ""
 "\t-v --verbose\n"
 "\t-V --version\t    skriv ut versionsnummer\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "okänd teckenuppsättning %s - ignorerar begäran om teckenuppsättning\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: fel när tangentbordsläge lästes: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -136,7 +136,7 @@ msgstr ""
 "(numeriskt värde, symbol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -159,42 +159,32 @@ msgstr ""
 "\t-V --version         visa programversionen\n"
 "\t-n --next-available  visa numret på nästa oallokerade VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Kunde inte läsa VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Kunde inte öppna %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Kunde inte få en filidentifierare för konsolen\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "användning: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Enkla avläsningskoder xx (hex) mot tangentkoder (dec)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 är ett fel, för 1-88 (0x01-0x58) är avläsningskoden lika med tangentkoden\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "för 1-%d (0x01-0x%02x) är avläsningskoden lika med tangentkoden\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -205,14 +195,14 @@ msgstr ""
 "\n"
 "Utvidgade avläsningskoder e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "misslyckades med att hämta tangentkoden för avläsningskod 0x%x: ioctl "
 "KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -249,72 +239,72 @@ msgstr "Fel: Inte tillräckligt med argument.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Fel: Okänd åtgärd: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "användning: kbd_mode [-a|-u|-k|-s] [-C enhet]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Tangentbordet är i rått (avläsningskods-)läge\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Tangentbordet är i halvrått (tangentkods-)läge\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Tangentbordet är i standardläge (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Tangentbordet är i Unicode-läge (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Tangentbordet är i något okänt läge\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Upprepningshastighet satt till %.1f t/s (fördröjning = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr ""
 "Användning: kbdrate [-V | --version] [-s] [-r frekvens] [-d fördröjning]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Kan inte öppna /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "fel: getfont anropad med count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "fel: getfont som använder GIO_FONT behöver buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: minnet slut\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "konstigt …  ct ändrades från %d till %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -323,21 +313,36 @@ msgstr ""
 "Det verkar som att denna kärna är äldre än 1.1.92\n"
 "Ingen Unicode-konverteringstabell inläst.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Kunde inte öppna %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Kunde inte få en filidentifierare för konsolen\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s från %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "minnet slut"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "kan inte initiera vektor: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Fel vid skrivning av tabell till fil"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "omöjligt: inte meta?\n"
@@ -357,71 +362,71 @@ msgstr "KDGKBSENT: %s: Kan inte hämta funktionstangentssträng"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: Kan inte hämta accenttabell"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "kan inte hämta tangenttabell %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "kan inte ta bort tangent %d i tabell %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key anropad med felaktig tangentkod %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "att lägga till tabell %d bryter mot explicit tangenttabellrad"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "kan inte sätta nyckel %d för tabell %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "omöjligt fel i lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "kan inte hämta symbol enligt fel typ: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "kan inte hämta symbol av typ %d enligt fel index: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "antar iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "antar iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "antar iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "antar iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "antar iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "okänd teckensymbol \"%s\"\n"
@@ -470,12 +475,12 @@ msgstr "KDSKBENT: %s: kan inte avallokera eller tömma tangenttabell"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: kunde inte återgå till originaltangentbordsläget"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "misslyckades att binda strängen ”%s” till funktionen %s"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "misslyckades att tömma strängen %s"
@@ -484,7 +489,7 @@ msgstr "misslyckades att tömma strängen %s"
 msgid "too many compose definitions"
 msgstr "för många kompositionsdefinitioner"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -499,21 +504,21 @@ msgstr[1] ""
 "\n"
 "Ändrade %d nycklar"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] "Ändrade %d sträng"
 msgstr[1] "Ändrade %d strängar"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "Laddade %d kompositionsdefinition"
 msgstr[1] "Laddade %d kompositionsdefinitioner"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Ingen ändring bland kompositionsdefinitioner)"
 
@@ -582,7 +587,7 @@ msgstr ""
 "\n"
 "Igenkända modifierarnamn och deras kolumnnummer:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -626,17 +631,12 @@ msgstr ""
 "  -v --verbose       rapportera ändringarna\n"
 "  -V --version       skriv ut versionsnummer\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s från %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: Flaggorna --unicode och --ascii är ömsesidigt uteslutande\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -645,7 +645,7 @@ msgstr ""
 "%s: varning: läser in en icke-Unicode-tangenttabell på en Unicode-konsol\n"
 "    (kanske du vill göra ”kbd_mode -a”?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -654,17 +654,17 @@ msgstr ""
 "%s: varning: läser in en Unicode-tangenttabell på en icke-Unicode-konsol\n"
 "    (kanske du vill göra ”kbd_mode -u”?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Hittar inte %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "kan inte öppna filen %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -673,29 +673,29 @@ msgstr ""
 "Användning:\n"
 "\t%s [-C konsol] [-o originaltabell]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Felaktig indatarad: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Glyfnummer (0x%x) större än typsnittslängd\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Felaktigt slut på intervall (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Felaktigt Unicode-intervall som motsvarar typsnittspositionsintervall 0x"
 "%x-0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -704,22 +704,22 @@ msgstr ""
 "%s: Unicode-intervall U+%x-U+%x är inte av samma längd som "
 "typsnittspositionsintervall 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: efterföljande skräp (%s) ignorerat\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Läser in Unicode-tabell från fil %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Varning: raden är för lång\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -728,85 +728,85 @@ msgstr ""
 "%s: läser inte in tom unitabell\n"
 "(om du insisterar: använd flaggan -f för att åsidosätta)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "post"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "poster"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Sparade Unicode-tabell till \"%s\"\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Lade till Unicode-tabell\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "användning: %s [-V] [-v] [-o originaltabell] tabellfil\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: kan inte öppna tabellfil _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Kan inte ta status på tabellfil"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Läser in binär direkt-till-typsnitt-skärmtabell från fil %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Fel vid läsning av tabell från fil \"%s\"\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Läser in binär Unicode-skärmfil från fil %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Läser in symbolisk skärmtabell från fil %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Fel vid tolkning av symbolisk tabell från \"%s\", rad %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Fel vid skrivning av tabell till fil\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Kan inte läsa konsoltabell\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Sparade skärmtabell i \"%s\"\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -839,11 +839,11 @@ msgstr ""
 "  -h, --help          skriv ut ett kort hjälpmeddelande.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Kunde inte hitta ägaren till den aktuella tty:n!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: Otillåtet vt-nummer"
@@ -891,96 +891,96 @@ msgstr "Använder VT %s"
 msgid "Cannot open %s read/write"
 msgstr "Kan inte öppna %s för läsning/skrivning"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Kunde inte aktivera vt %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Aktiveringen avbröts?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Kunde inte avallokera konsol %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: kort ucs2-Unicode-tabell\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: kort utf8-Unicode-tabell\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: felaktig utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: okänt utf8-fel\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: kort Unicode-tabell\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Fel vid läsning av indatatypsnitt"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Felaktigt anrop av readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: psf-filläge (%d) stödjs inte\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: psf-version (%d) stödjs inte\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: längd av indatatypsnitt är noll?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: storlek av indatatecken är noll?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Indatafil: ogiltig indatalängd (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Indatafil: efterföljande skräp\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: ogiltig Unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Kan inte skriva typsnittsfilshuvud"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Kan inte skriva till typsnittsfilen"
@@ -1065,39 +1065,49 @@ msgstr "%s: psf-fil med okänd magi\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: indatatypsnittet har inte något index\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: kan inte hitta videolägesfil %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: kan inte hitta videolägesfil %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Ogiltigt antal rader\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Gammalt läge: %d×%d  Nytt läge: %d×%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 "Gammalt antal skannlinjer: %d  Nytt antal skannlinjer: %d  Teckenhöjd: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: kommandot \"%s\" misslyckades\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: glöm inte ändra TERM (kanske till con%dx%d eller linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1110,41 +1120,41 @@ msgstr ""
 "eller: resizecons -lines RADER, där RADER är en av 25, 28, 30, 34, 36, 40, "
 "44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: kan inte få I/O-rättigheter.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "användning: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Fel vid läsning av %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "kunde inte läsa %s, och kan inte köra \"ioctl dump\"\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "kunde inte läsa %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Konstigt ... skärmen är både %d×%d och %d×%d??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Fel vid skrivning av skärmdump\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1199,12 +1209,12 @@ msgstr ""
 "    -V         Skriv ut version och avsluta.\n"
 "Filer läses in från den aktuella katalogen eller %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: för många indatafiler\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1213,123 +1223,123 @@ msgstr ""
 "setfont: kan inte både återställa från tecken-ROM och från fil.  Typsnittet "
 "oförändrat.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Felaktig teckenhöjd %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Felaktig teckenbredd %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: typsnittsposition 32 är icke-blank\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: rensade det\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: bakgrunden kommer se konstig ut\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Läser in %d-teckens %d×%d-typsnitt från filen %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Läser in %d-teckens %d×%d-typsnitt\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Läser in %d-teckens %d×%d-typsnitt (%d) från filen %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Läser in %d-teckens %d×%d-typsnitt (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: fel i do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Läser in Unicode-konverteringsstabell …\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Kan inte öppna typsnittsfilen %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "När flera typsnitt läses in måste alla vara psf-typsnitt - %s är inte det\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Läste %d-teckens %d×%d-typsnitt från filen %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "När flera typsnitt läses in måste alla ha samma höjd\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "När flera typsnitt läses in måste alla ha samma bredd\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Hittar inte standardtypsnittet\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Hittar inte typsnittet %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Läser typsnittsfilen %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Inget slutgiltigt nyradstecken i kombinationsfilen\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "För många filer att kombinera\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - ett typsnitt från restorefont? Använder första halvan.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Felaktig storlek på indatafilen\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1338,23 +1348,23 @@ msgstr ""
 "Den här filen innehåller 3 typsnitt: 8×8, 8×14 och 8×16. Välj vilket\n"
 "du vill läsa in med någon av flaggorna -8, -14 och -16.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Du bad om typsnittsstorleken %d, men bara 8, 14 och 16 är möjliga här.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Hittade inget att spara\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Sparade %d-teckens %d×%d-typsnittsfil till %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1365,19 +1375,19 @@ msgstr ""
 " (där avläsningskod är antingen xx eller e0xx angivet hexadecimalt,\n"
 "  och tangentkod är angivet decimalt)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "jämnt antal argument förväntades"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "fel vid läsning av avläsningskod"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "kod utanför gränserna"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1557,12 +1567,12 @@ msgstr "gammalt tillstånd:    "
 msgid "new state:    "
 msgstr "nytt tillstånd:       "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "användning: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1597,40 +1607,40 @@ msgstr ""
 "   -V     skriv ut versionsnummer\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Fel: %s: Felaktigt värde i fält %u på rad %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Fel: %s: Otillräckligt antal fält på rad %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Fel: %s: Rad %u slutade oväntat.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Fel: %s: Rad %u är för lång.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr ""
 "misslyckades med att återställa den ursprungliga översättningstabellen\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "misslyckades med att återställa den ursprungliga uni-tabellen\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "kan inte ändra översättningstabellen\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1679,16 +1689,16 @@ msgstr ""
 "Visar %d-teckens typsnitt\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?OKÄNT?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "tgb-läge var %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1697,12 +1707,12 @@ msgstr ""
 "[ om du gör det här i X kanske det inte fungerar\n"
 "eftersom X-servern också läser /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "fick signalen %d, städar upp...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1760,11 +1770,11 @@ msgstr "tryck"
 msgid "keycode %3d %s\n"
 msgstr "tangentkod %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "användning: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1774,17 +1784,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Hela konsoldisplayen är nu helt låst av %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "%s är nu låst av %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 "Använd Alt-funktionstangenter för att byta till andra virtuella konsoler."
@@ -1794,7 +1804,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr "Prova ”%s --help” för mer information.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1822,16 +1832,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "okänd användare"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "standard in är inte en tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Denna tty (%s) är inte en virtuell konsol.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Hela konsoldisplayen kan inte låsas.\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 1.10\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2004-01-21 06:15+0300\n"
 "Last-Translator: Nilgün Belma Bugüner <nilgun@superonline.com>\n"
 "Language-Team: Turkish <gnu-tr-u12a@lists.sourceforge.net>\n"
@@ -16,48 +16,48 @@ msgstr ""
 "X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: KBabel 1.0\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "kullanimi: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 #, fuzzy
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Konsolu hedef alan bir dosya betimleyici (fd) alinamadi\n"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: bilinmeyen secenek\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 #, fuzzy
 msgid "0: illegal VT number\n"
 msgstr "%s: 0: VT numarasi uygun degil\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 #, fuzzy
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "%s: VT 1 konsolun kendisi ve kaldirilamaz\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, fuzzy, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "%s: %d konsolu kaldirilamadi\n"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys %s surumu"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -93,7 +93,7 @@ msgstr ""
 "     --compose-only    sadece tu$-dizgi ili$kileri gosterilir\n"
 "  -c --charset=        "
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -102,24 +102,24 @@ msgstr ""
 "                       eylem kodalrini belirtilen karakter kumesine\n"
 "                       gore yorumlar\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "%s karakter seti bilinmiyor - istek yoksayildi\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, fuzzy, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: klavye kipi ayarlanirken hata\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -130,7 +130,7 @@ msgstr ""
 "(sayisal deger, sembol)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -144,46 +144,36 @@ msgid ""
 "\t-n --next-available  display number of next unallocated VT\n"
 msgstr ""
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 #, fuzzy
 msgid "Couldn't read VTNO: "
 msgstr "%s okunamadi\n"
 
-#: src/getfd.c:69
-#, fuzzy, c-format
-msgid "Couldn't open %s\n"
-msgstr "%s acilamadi\n"
-
-#: src/getfd.c:86
-#, fuzzy, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Konsolu hedef alan bir dosya betimleyici (fd) alinamadi\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "kullanimi: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Tu$ kodlarina (onluk) kar$i du$en basit tarama kodlari (onaltilik)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 bir hatadir; 1-88 (0x01-0x58) tarama kodlari tu$ kodlariyla ayni oldugu "
 "icin\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, fuzzy, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr ""
 "0 bir hatadir; 1-88 (0x01-0x58) tarama kodlari tu$ kodlariyla ayni oldugu "
 "icin\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -194,12 +184,12 @@ msgstr ""
 "\n"
 "Oncelemeli tarama kodlari e0 xx (onaltilik)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, fuzzy, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "0x%x tarama kodu icin tu$ kodu alinamadi\n"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -231,94 +221,109 @@ msgstr ""
 "bilinmeyen arguman: _%s_\n"
 "\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, fuzzy, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "kullanimi: kbd_mode [-a|-u|-k|-s]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Klavye tarama kodlari (temel) kipinde\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Klavye tu$ kodlari (temelustu) kipinde\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Klavye ontanimli (ASCII) kipte\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Klavye Unicode (UTF-8) kipinde\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Klavye bilinmeyen bir kipte\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Yineleme hizi %.1f cps (gecikme = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Kullanimi: kbdrate [-V] [-s] [-r hiz] [-d gecikme]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "/dev/port acilamiyor"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "yazilim hatasi: getfont sayac<256 ile cagrildi\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr ""
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: bellek yetersiz\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr ""
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
 "No Unicode mapping table loaded.\n"
 msgstr ""
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, fuzzy, c-format
+msgid "Couldn't open %s\n"
+msgstr "%s acilamadi\n"
+
+#: src/libcommon/getfd.c:86
+#, fuzzy, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Konsolu hedef alan bir dosya betimleyici (fd) alinamadi\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s (%s den)\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 #, fuzzy
 msgid "out of memory"
 msgstr "%s: bellek yetersiz\n"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr ""
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 #, fuzzy
 msgid "Error writing map to file"
 msgstr "E$lem dosyaya yazilirken hata\n"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "imkansiz: meta degil?\n"
@@ -338,71 +343,71 @@ msgstr ""
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr ""
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, fuzzy, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "0x%x tarama kodu icin tu$ kodu alinamadi\n"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr ""
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr ""
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, fuzzy, c-format
 msgid "unable to set key %d for table %d"
 msgstr "0x%x tarama kodu icin tu$ kodu alinamadi\n"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr ""
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, fuzzy, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "iso-8859-1'deki  %s oldugu varsayildi\n"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, fuzzy, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "iso-8859-15'deki  %s oldugu varsayildi\n"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, fuzzy, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "iso-8859-2'deki  %s oldugu varsayildi\n"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, fuzzy, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "iso-8859-3'deki %s oldugu varsayildi\n"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, fuzzy, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "iso-8859-4'deki %s oldugu varsayildi\n"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "'%s' sembolu bilinmiyor\n"
@@ -451,12 +456,12 @@ msgstr ""
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr ""
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr ""
@@ -466,7 +471,7 @@ msgstr ""
 msgid "too many compose definitions"
 msgstr "en fazla dizgi tanimi sayisi: %d\n"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -477,21 +482,21 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, fuzzy, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "en fazla dizgi tanimi sayisi: %d\n"
 msgstr[1] "en fazla dizgi tanimi sayisi: %d\n"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 #, fuzzy
 msgid "(No change in compose definitions)"
 msgstr "en fazla dizgi tanimi sayisi: %d\n"
@@ -561,7 +566,7 @@ msgstr ""
 "\n"
 "Tanimli degi$tirici isimleri ve sutun numaralari:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -586,41 +591,36 @@ msgid ""
 "  -V --version       print version number\n"
 msgstr ""
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s (%s den)\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
 "    (perhaps you want to do `kbd_mode -a'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
 "    (perhaps you want to do `kbd_mode -u'?)\n"
 msgstr ""
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, fuzzy, c-format
 msgid "Cannot find %s\n"
 msgstr "%s yazitipi bulunamiyor\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, fuzzy, c-format
 msgid "cannot open file %s\n"
 msgstr "%s yazitipi dosyasi acilamiyor\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -629,29 +629,29 @@ msgstr ""
 "Kullanimi:\n"
 "\t%s [-C konsol] [-o eslem.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "girdi satiri hatali: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: (0x%x) karakter numarasi yazitipi uzunlugundan fazla\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: aralik sonu hatali (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Unicode araliginin 0x%x-0x%x yazitipi konumlari araligi ile ili"
 "$kilendirilmesi hatali\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -661,22 +661,22 @@ msgstr ""
 "yazitipi konumlari araligi 0x%x-0x%x\n"
 "ile ayni uzunlukta degil\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: geri kalan (%s) yoksayildi\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "%s dosyasindan Unicode e$lem yukleniyor\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Uyari: satir cok uzun\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -685,85 +685,85 @@ msgstr ""
 "%s: bo$ Unicode e$lem yuklenmez\n"
 "(israr ediyorsaniz: -f secenegi ile a$abilirsiniz)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "girdi"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "girdi"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "`%s'dosyasina Unicode e$lem kaydedildi\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Unicode e$lem eklendi\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "kullanimi: %s [-v] [-o e$lem.ozgun] e$lem-dosyasi\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: _%s_ e$lem dosyasi acilamadi\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "e$lem dosyasi durum bilgileri alinamiyor"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "ikilik dogrudan yazitipine ekran e$lem dosyasi %s yukleniyor\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "`%s' dosyasindan e$lem okunurken hata\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "ikilik unicode ekran e$lem dosyasi %s yukleniyor\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Sembolik ekran e$lemi %s dosyasindan yukleniyor\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Sembolik e$lem `%s' dosyasindan cozumlenirken %d. satirda hata\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "E$lem dosyaya yazilirken hata\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "konsol e$lemi okunamiyor\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Ekran e$lemi `%s' dosyasina kaydedildi\n"
 
-#: src/openvt.c:49
+#: src/openvt.c:48
 #, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -779,14 +779,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr ""
 
 # Dikkat: utf-8 ve iso kiplerde karakter kaybina ugramadan
 # iletilerin duzgun okunabilmesi icin sadece bu pakette
 # Turkce'ye ozgu karakterlerden kacinilmi$tir.
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, fuzzy, c-format
 msgid "%s: Illegal vt number"
 msgstr "openvt: %s: kuraldisi sanal terminal (vt) numarasi\n"
@@ -835,96 +835,96 @@ msgstr "openvt: VT %s kullanarak\n"
 msgid "Cannot open %s read/write"
 msgstr "openvt: %s oku/yaz kipinde acilamiyor (%s)\n"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr ""
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr ""
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, fuzzy, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "%s: %d konsolu kaldirilamadi\n"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: kisa ucs2 unicode tablosu\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: kisa utf8 unicode tablosu\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: hatali utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: bilinmeyen utf8 hatasi\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: kisa unicode tablosu\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: giri$ yazitipi okunurken hata"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: readpsffont cagrisi hatali\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Desteklenmeyen psf dosya kipi (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: Desteklenmeyen psf surumu (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: sifir giri$ yazitipi uzunlugu?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: sifir giri$ karakteri uzunlugu?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Girdi dosyasi: girdi uzunlugu (%d) hatali\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Girdi dosyasi: kalan bozuk\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: kuraldi$i unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Yazitipi dosyasinin basligi yazilamiyor"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Yazitipi dosyasi yazilamiyor"
@@ -1010,21 +1010,31 @@ msgstr "%s: psf dosyasindaki dosya betimleyici bilinmiyor\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: girdi yazitipi bir indekse sahip degil\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: %s video kipi dosyasi bulunamiyor\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: %s video kipi dosyasi bulunamiyor\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Satir sayisi gecersiz\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Eski kip: %dx%d  Yeni kip: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
@@ -1032,12 +1042,12 @@ msgstr ""
 "Yeni tarama-satirlari sayisi: %d\n"
 "Karakter yuksekligi:          %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: komut `%s' ba$arisiz\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1045,7 +1055,7 @@ msgstr ""
 "resizecons: TERM cevre degi$kenini degi$tirmeyi unutmayin\n"
 "(con%dx%d veya linux-%dx%d olabilir)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1059,41 +1069,41 @@ msgstr ""
 "    ya da:  resizecons -lines SATIR-SAYISI\n"
 "SATIR-SAYISI 25, 28, 30, 34, 36, 40, 44, 50, 60 degerlerinden biri olabilir\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: G/C izinleri alinamiyor.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "Kullanimi: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, fuzzy, c-format
 msgid "Error reading %s"
 msgstr "%s okunurken hata\n"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "%s okunamadi, ve ioctl dokumlenemiyor\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "%s okunamadi\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Tuhaf ... %dx%d ve %dx%d her ikisi de ekran mi??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "screendump yazmada ba$arisiz\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, fuzzy, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1148,12 +1158,12 @@ msgstr ""
 "    -V         surum bilgilerini gosterir ve cikar\n"
 "Dosyalar cali$ilan dizinden ya da /usr/lib/kbd/*/ dizininden yuklenir.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: cok fazla girdi dosyasi\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1162,123 +1172,123 @@ msgstr ""
 "setfont: hem ekran kartindan hem de dosyadan yuklenemez. Yazitipi degi"
 "$medi.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Karakter yuksekligi %d hatali\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Karakter geni$ligi %d hatali\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: 32. yazitipi konumu bo$luk degil\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: o silindi\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: artalan tuhaf gorunecek\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "%d karakterlik %dx%d yazitipi %s dosyasindan yukleniyor\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "%d karakterlik %dx%d yazitipi yukleniyor\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "%d karakterlik %dx%d (%d) yazitipi %s dosyasindan yukleniyor\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "%d karakterlik %dx%d (%d) yazitipi yukleniyor\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: do_loadtable'da yazilim hatasi\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Unicode e$le$me tablosu yukleniyor...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "%s yazitipi dosyasi acilamiyor\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Ayri ayri yazitipleri yuklenirken tumu psf yazitipi olmali - %s degil\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "%d karakterlik %dx%d yazitipi %s dosyasindan okundu\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Ayri ayri yazitipleri yuklenirken hepsi ayni yukseklikte olmali\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "Ayri ayri yazitipleri yuklenirken hepsi ayni geni$likte olmali\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "\"default.cp[gz]\" yazitipi dosyasi bulunamiyor\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "%s yazitipi bulunamiyor\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "%s yazitipi dosyasi okunuyor\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Birle$ik dosya icinde son satirsonu imi yok\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Birle$tirilecek dosya sayisi cok fazla\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hmm - restorefont'tan bir yazitipi? ilk yarisi kullaniliyor.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Girdi dosyasi uzunlugu hatali\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1287,24 +1297,24 @@ msgstr ""
 "Bu dosya 3 yazitipi icerir: 8x8, 8x14 ve 8x16.  istediginiz birini\n"
 "-8, -14 veya -16 seceneklerinden biri ile belirtebilirsiniz.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Yazitipi yuksekligini %d belirttiniz ama burada sadece 8, 14, 16\n"
 "degerleri mumkun.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Kaydedilecek hicbir sey yok\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "%d karakterlik %dx%d yazitipi %s dosyasina kaydedildi\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1315,19 +1325,19 @@ msgstr ""
 " (burada tarama-kodu onaltilik (xx veya e0xx) ve\n"
 "  tu$-kodu onluk bicimde verilmelidir)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "arguman sayisinin cift-sayi olmasi gerekli"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "tarama kodlari okunurken hata"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "kod kabul edilen sinirin di$inda"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, fuzzy, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "tarama kodu %x tu$ kodu %d ile e$le$tirilirken hata olu$tu\n"
@@ -1512,12 +1522,12 @@ msgstr "eski durum:    "
 msgid "new state:    "
 msgstr "yeni durum:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "kullanimi: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1537,39 +1547,39 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr ""
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr ""
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, fuzzy, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "%s: %s: Uyari: satir cok uzun\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "ozgun ceviri tablosu yerine konurken hata olu$tu\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "ozgun unicode e$lem yerine konamadi\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "ceviri tablosu degistirilemiyor\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1606,16 +1616,16 @@ msgid ""
 "\n"
 msgstr "%d karakterlik %dx%d yazitipi yukleniyor\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?BiLiNMEYEN?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "klavye kipi %s idi\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1624,12 +1634,12 @@ msgstr ""
 "[ Eger bunu X altinda deniyorsaniz, X sunucusu\n"
 "/dev/console'u okuyana kadar cali$mayabilir ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "%d sinyali yakalandi, temizleniyor...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1690,29 +1700,29 @@ msgstr "basim"
 msgid "keycode %3d %s\n"
 msgstr "tu$ kodu %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 #, fuzzy
 msgid "usage: totextmode\n"
 msgstr "kullanimi: getkeycodes\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
 "\n"
 msgstr ""
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr ""
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 
@@ -1721,7 +1731,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr ""
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1742,16 +1752,16 @@ msgstr ""
 "bilinmeyen arguman: _%s_\n"
 "\n"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr ""
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr ""
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, fuzzy, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "%s: VT 1 konsolun kendisi ve kaldirilamaz\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-12-27 13:13+0200\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <translation-team-uk@lists.sourceforge.net>\n"
@@ -20,45 +20,45 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
 "%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "використання: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Не вдалося отримати файловий дескриптор, що відповідає консолі"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: невідомий параметр\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: некоректний номер VT\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 є системною консоллю та не може бути звільнений\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "не вдалося звільнити консоль %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys версії %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -97,7 +97,7 @@ msgstr ""
 "\t-d --compose-only   вивести лише комбінації сполучених клавіш\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -106,7 +106,7 @@ msgstr ""
 "\t\t\t    інтерпретувати коди дій у символах як у вказаному\n"
 "\t\t\t    наборі символів\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -115,17 +115,17 @@ msgstr ""
 "\t-v --verbose\n"
 "\t-V --version\t    вивести дані щодо номера версії\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "невідомий набір символів %s - вказування набору символів ігнорується\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: помилка під час спроби читання режиму роботи клавіатури: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -136,7 +136,7 @@ msgstr ""
 "(числове значення, символ)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -159,41 +159,31 @@ msgstr ""
 "\t-V --version         показати дані щодо версії програми\n"
 "\t-n --next-available  показати номер наступного не розподіленого VT\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Не вдалося прочитати значення VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Не вдалося відкрити %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Не вдалося отримати файловий дескриптор, що відповідає консолі\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "використання: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "Прямі скан-коди xx (hex) проти кодів клавіш (десяткові)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr "0 - помилка; скан-коди 1--88 (0x01--0x58) дорівнюють кодам клавіш\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "для 1 %d (0x01-0x%02x) скан-код дорівнює коду клавіші\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -204,14 +194,14 @@ msgstr ""
 "\n"
 "Скан-коди з `Escape' e0 xx (hex)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "не вдалося знайти код клавіші, що відповідає скан-коду 0x%x: ioctl "
 "KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -248,74 +238,74 @@ msgstr "Помилка: недостатньо аргументів\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Помилка: невідома дія: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "використання: kbd_mode [-a|-u|-k|-s] [-C пристрій]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Клавіатура знаходиться у сирому (raw) режимі (надсилає скан-коди)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Клавіатура знаходиться у напівсирому режимі (надсилає коди клавіш)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr ""
 "Клавіатура знаходиться у звичайному режимі (надсилає ASCII-коди знаків)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr ""
 "Клавіатура знаходиться у режимі Unicode (надсилає коди знаків у UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Клавіатура знаходиться у невідомому режимі\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Значення частоти повтору: %.1f симв/сек (затримка = %d мс)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr ""
 "Користування: kbdrate [-V | --version] [-s] [-r частота] [-d затримка]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Не вдалося відкрити /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "помилка: getfont виконано з count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "помилка: використання GIO_FONT у getfont потребує визначення буфера.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: недостатньо пам'яті\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "дивно... ct змінено з %d на %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -324,21 +314,36 @@ msgstr ""
 "Версія ядра є старішою за 1.1.92\n"
 "Таблиці відповідності Unicode не завантажено.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Не вдалося відкрити %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Не вдалося отримати файловий дескриптор, що відповідає консолі\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s з %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "недостатньо пам'яті"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "не вдалося ініціалізувати масив: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Помилка запису у файл"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "неможливо: не `meta'?\n"
@@ -358,71 +363,71 @@ msgstr "KDGKBSENT: %s: не вдалося отримати рядок функ�
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: не вдалося отримати таблицю акцентів"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "не вдалося отримати розкладку %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "не вдалося скасувати визначення клавіші %d для таблиці %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key викликано з помилковим кодом клавіші %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "додавання розкладки %d суперечить рядку явного визначення розкладки"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "не вдалося визначити клавішу %d для таблиці %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "неможлива помилка у lk_add_constants"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "не вдалося отримати символ за помилковим типом: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "не вдалося отримати символ типу %d за помилковим індексом: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "припускаємо iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "припускаємо iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "припускаємо iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "припускаємо iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "припускаємо iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "невідомий keysym `%s'\n"
@@ -472,12 +477,12 @@ msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr ""
 "KDSKBMODE: %s: не вдалося повернутися до початкового режиму роботи клавіатури"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "не вдалося пов’язати рядок «%s» з функцією %s"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "не вдалося спорожнити рядок %s"
@@ -486,7 +491,7 @@ msgstr "не вдалося спорожнити рядок %s"
 msgid "too many compose definitions"
 msgstr "занадто багато визначень сполучень"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -507,7 +512,7 @@ msgstr[3] ""
 "\n"
 "Змінено %d клавішу"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
@@ -516,7 +521,7 @@ msgstr[1] "Змінено %d рядки"
 msgstr[2] "Змінено %d рядків"
 msgstr[3] "Змінено %d рядок"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
@@ -525,7 +530,7 @@ msgstr[1] "Завантажено %d визначення сполучень"
 msgstr[2] "Завантажено %d визначень сполучень"
 msgstr[3] "Завантажено %d визначення сполучення"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Немає змін у визначеннях сполучених клавіш.)"
 
@@ -594,7 +599,7 @@ msgstr ""
 "\n"
 "Відомі назви модификаторів та номери відповідних колонок: \n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -639,17 +644,12 @@ msgstr ""
 "  -v --verbose       повідомити про внесені зміни\n"
 "  -V --version       вивести номер версії\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s з %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: параметри --unicode і --ascii не можна використовувати одночасно\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -658,7 +658,7 @@ msgstr ""
 "%s: попередження: завантаження не-Unicode-розкладки до консолі Unicode\n"
 "    (можливо, вам варто виконати «kbd_mode -a»?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -667,17 +667,17 @@ msgstr ""
 "%s: попередження: завантаження Unicode-розкладки до не-Unicode-консолі\n"
 "    (можливо, вам варто виконати «kbd_mode -u»?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Не вдалося знайти %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "не вдалося відкрити файл %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -686,29 +686,29 @@ msgstr ""
 "Використання:\n"
 "\t%s [-C консоль] [-o map.orig]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Неправильний рядок на вході: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: Номер знаку (0x%x) більший ніж кількість знаків у цьому шрифті\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Неправильний кінець діапазону (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Неприпустимий Unicode-діапазон, що відповідає діапазону шрифту 0x%x--0x"
 "%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -717,22 +717,22 @@ msgstr ""
 "%s: Довжина Unicode-діапазону U+%x-U+%x відрізняється від довжини діапазону "
 "шрифту 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: сміття наприкінці (%s) ігнорується\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Завантажується unicode-схема з файлу %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Попередження: надто довгий рядок\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -741,86 +741,86 @@ msgstr ""
 "%s: не можна завантажувати порожню unimap\n"
 "(якщо ви наполягаєте, скористайтесь параметром `-f')\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "пункт"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "пункти"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Збережено unicode-схему до `%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Додано у Unicode-схему\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr ""
 "Користування: %s [-V] [-v] [-o початкова_розкладка] файл_з_розкладкою\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: неможливо відкрити файл \"%s\"\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Не вдалося отримати інформацію про файл (stat)"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "Завантажується схема відображення з екрану та з файлу %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Помилка читання розкладки з файлу %s\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Завантажується схема відображення екрану з файлу %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Завантажується опис схеми відображення екрану з файлу %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Помилка розбору описану схеми відображення з `%s', рядок %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Помилка запису у файл\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Не вдалося прочитати схему відображення консолі\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Схема відображення екрану збережена у `%s'\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -854,11 +854,11 @@ msgstr ""
 "  -h, --help          показати коротке довідкове повідомлення.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "Не вдалося визначити власника поточного tty!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: некоректний номер VT"
@@ -908,96 +908,96 @@ msgstr "Використовується VT %s"
 msgid "Cannot open %s read/write"
 msgstr "Не вдалося відкрити %s для читання або запису"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Не вдалося активувати VT %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Активацію перервано?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "не вдалося звільнити консоль %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: коротка таблиця Юнікоду ucs2\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: коротка таблиця Юнікоду utf8\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: неправильний utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: невідома помилка utf8\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: коротка таблиця Юнікоду\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: помилка читання вхідного шрифту"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: неправильний виклик readpsffont\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: непідтримуваний режим файлу psf (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: непідтримувана версія psf (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: нульова довжина вхідного шрифту?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: нульовий розмір знаку на вході?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Вхідний файл: неправильна довжина вхідного файлу (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: вхідний файл: сміття наприкінці файлу\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: некоректний unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Не вдалося записати заголовок файлу шрифту"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Не вдалося записати файл шрифту"
@@ -1081,40 +1081,50 @@ msgstr "%s: файл psf з невідомою сигнатурою\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: вхідний шрифт не має індексу\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: не вдалося знайти файл відеорежиму %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: не вдалося знайти файл відеорежиму %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Неприпустима кількість рядків\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Попередній режим: %dx%d  Новий режим: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr ""
 "Рядків розгортки у попередньому режимі: %d    У новому: %d    Висота шрифту: "
 "%d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: помилка команди `%s'\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr ""
 "resizecons: не забудьте змінити TERM (можливо, на con%dx%d або linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1127,41 +1137,41 @@ msgstr ""
 "   або: tresizecons -lines РЯДКІВ, де параметр РЯДКІВ може мати значення:\n"
 "        25, 28, 30, 34, 36, 40, 44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: не вдалося отримати права доступу до вводу-виводу.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "використання: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Помилка читання %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "Не вдалося прочитати %s та викликати дамп (ioctl dump)\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "не вдалося прочитати %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Дивно ... екран одночасно %dx%d та %dx%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Помилка запису екранного дампу\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1216,12 +1226,12 @@ msgstr ""
 "    -V         Вивести версію.\n"
 "Файли завантажуються з поточного каталогу або з %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: надто багато вхідних файлів\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1230,125 +1240,125 @@ msgstr ""
 "setfont: не вдалося ставити шрифт одразу з ПЗУ, та з файлу. Шрифт НЕ "
 "змінено.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Неприпустима висота символу %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Неприпустима ширина символу %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: позиція шрифту 32 не порожня\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: витерти її\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: тло буде виглядати смішно\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Завантажується %d-знаковий шрифт %dx%d з файлу %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Завантажується %d-знаковий шрифт %dx%d\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Завантажується %d-знаковий шрифт %dx%d (%d) з файлу %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Завантажується %d-знаковий шрифт %dx%d (%d)\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: помилка у do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Завантажується Unicode-таблиця...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Не вдалося відкрити файл %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "При завантаженні кількох шрифтів, усі мають бути psf-шрифтами - %s не є "
 "таким\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Завантажується %d-знаковий шрифт %dx%d з файлу %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "При завантаженні кількох шрифтів, усі мають бути однакової висоти\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr ""
 "При завантаженні кількох шрифті, усі повинні мати однакову ширину символів\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Не вдалося знайти основний шрифт\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Не вдалося знайти шрифт %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Читається файл зі шрифтом %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Відсутній завершальний порожній рядок у об'єднаному файлі\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Надто багато файлів для об'єднання\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Ой... шрифт з restorefont? Використовується перша половина.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Неприпустимий розмір вхідного файлу\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1358,22 +1368,22 @@ msgstr ""
 "Вкажіть одним з ключів: -8, -14 чи -16,\n"
 "який саме шрифт завантажувати.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr "Ви вказали шрифт із розміром %d, але можливі лише 8, 14 чи 16.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Немає що записувати\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Записано %d-знаковий шрифт %dx%d у файл %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1384,19 +1394,19 @@ msgstr ""
 "Скан-код треба вказувати у шістнадцятковому вигляді: xx чи e0xx,\n"
 "код клавіші - у десятковій формі.\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "очікується парна кількість аргументів"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "помилка читання скан-коду"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "код поза допустимим діапазоном"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "помилка встановлення скан-коду %x коду %d: ioctl KDSETKEYCODE"
@@ -1574,12 +1584,12 @@ msgstr "попередній стан:     "
 msgid "new state:    "
 msgstr "новий стан:          "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "використання: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1611,39 +1621,39 @@ msgstr ""
 "з подальшим редагуванням даних у отриманому файлі.\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Помилка: %s: некоректне значення у полі %u, рядок %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Помилка: %s: недостатня кількість полів у рядку %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Помилка: %s: незавершений рядок %u.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Помилка: %s: рядок %u є занадто довгим.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "помилка відновлення початкової таблиці перетворень\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "не вдалося відновити початкову таблицю unimap\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "не вдалося змінити таблицю перетворень\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1693,16 +1703,16 @@ msgstr ""
 "Показ %d-знакового шрифту\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?НЕВІДОМО?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "режим клавіатури був %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1711,12 +1721,12 @@ msgstr ""
 "[ якщо Ви намагаєтесь виконати команду у X-Window,\n"
 "можливо, вона не працюватиме, оскільки X-сервер теж читає /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "отримано сигнал %d, очищення...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1775,11 +1785,11 @@ msgstr "натиснута"
 msgid "keycode %3d %s\n"
 msgstr "клавіша %3d (код) %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "використання: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1789,17 +1799,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "Показ даних у консолі тепер повністю заблоковано %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "%s тепер заблоковано %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr ""
 "Скористайтеся комбінацією Alt-функціональна клавіша для перемикання на інші "
@@ -1810,7 +1820,7 @@ msgstr ""
 msgid "Try `%s --help' for more information.\n"
 msgstr "Віддайте команду «%s --help», щоб дізнатися більше.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1837,16 +1847,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "невідомий користувач"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "стандартне джерело даних не є пристроєм tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "Цей пристрій tty (%s) не є віртуальною консоллю.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Показ даних у консолі не може бути повністю заблоковано.\n"

--- a/po/vi.po
+++ b/po/vi.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.4-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2016-12-28 13:46+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -23,45 +23,45 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "cách dùng: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "Không thể lấy mô tả tập tin mà chỉ đến thiết bị điều khiển"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: không hiểu tùy chọn\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: số VT không hợp lệ\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 là một thiết bị điều khiển và không thể bị bỏ phân phối\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "không thể bỏ phân phối thiết bị điều khiển %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "phiên bản dumpkeys %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, c-format
 msgid ""
 "\n"
@@ -100,7 +100,7 @@ msgstr ""
 "\t-d --compose-only   chỉ hiện thị tổ hợp phím soạn thảo\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -109,7 +109,7 @@ msgstr ""
 "\t\t\t    dịch mã hoạt động của phím từ\n"
 "\t\t\t    bảng mã chỉ ra\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
@@ -118,17 +118,17 @@ msgstr ""
 "\t-v --verbose\n"
 "\t-V --version\t    hiển thị số hiệu phiên bản\n"
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "không rõ bảng mã %s - lờ đi yêu cầu bảng mã\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: gặp lỗi khi đọc chế độ bàn phím: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -139,7 +139,7 @@ msgstr ""
 "(giá trị số, ký hiệu)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -162,44 +162,34 @@ msgstr ""
 "\t-V --version         hiển thị phiên bản chương trình\n"
 "\t-n --next-available  hiển thị số thứ tự của VT được cấp phát kế tiếp\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "Không thể đọc VTNO: "
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "Không thể mở %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "Không thể lấy bộ mô tả tập tin mà nó chỉ đến thiết bị điều khiển\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "cách dùng: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr ""
 "Mã quét (scancode) đơn giản xx (hệ mười sáu) đối lập với mã phím (hệ mười)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr ""
 "0 là một lỗi; đối với 1-88 (0x01-0x58) mã quét (scancode) bằng mã phím "
 "(keycode)\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "đối với 1-%d (0x01-0x%02x) mã quét (scancode) bằng mã phím (keycode)\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -210,14 +200,14 @@ msgstr ""
 "\n"
 "Mã quét (scancode) thoát e0xx (hệ bát phân)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr ""
 "gặp lỗi khi lấy mã phím (keycode) cho mã quét (scancode) 0x%x: ioctl "
 "KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -254,71 +244,71 @@ msgstr "Lỗi: không có đủ đối số.\n"
 msgid "Error: Unrecognized action: %s\n"
 msgstr "Lỗi: Thao tác không được chấp nhận: %s\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "cách dùng: kbd_mode [-a|-u|-k|-s] [-C thiết_bị]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "Bàn phím ở trong chế độ thô (scancode)\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "Bàn phím ở trong chế độ thô trung bình (keycode)\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "Bàn phím ở trong chế độ mặc định (ASCII)\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "Bàn phím ở trong chế độ Unicode (UTF-8)\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "Bàn phím ở trong một chế độ chưa được biết đến\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "Tốc độ “Typematic” đặt thành  %.1f cps (chậm trễ = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "Cách dùng: kbdrate [-V | --version] [-s] [-r tốc_độ] [-d độ_trễ]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "Không thể mở /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "lỗi (bug): getfont được gọi với số lượng <256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "lỗi: getfont dùng GIO_FONT thì dùng buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: hết bộ nhớ\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "lạ thật… ct bị thay đổi từ %d thành %d\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -327,21 +317,36 @@ msgstr ""
 "Hình như là nhân (kernel) có phiên bản cũ hơn 1.1.92\n"
 "Không có bảng ánh xạ Unicode được tải lên.\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "Không thể mở %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "Không thể lấy bộ mô tả tập tin mà nó chỉ đến thiết bị điều khiển\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s từ %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "hết bộ nhớ"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "không thể khởi tạo mảng: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "Lỗi ghi nhớ ánh xạ vào tập tin"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "không thể: không phải meta?\n"
@@ -361,71 +366,71 @@ msgstr "KDGKBSENT: %s: Không thể lấy chuỗi khóa hàm"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: Không thể lấy bảng trọng âm"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "không thể lấy ánh xạ phím %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "không thể bỏ đặt phím %d cho bảng %d"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "lk_add_key được gọi với mã phím sai %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "việc thêm ánh xạ %d thì vi phạm dòng ánh xạ phím dứt khoát"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "không thể đặt phím %d cho bảng %d"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "gần như chắc chắn là lk_add_constans có chứa lỗi"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "không thể lấy ký hiệu bằng kiểu sai: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "không thể lấy ký hiệu của kiểu %d bằng chỉ số sai: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "coi là iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "coi là iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "coi là iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "coi là iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr "coi là iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "không rõ ký tự phím (keysym) “%s”\n"
@@ -474,12 +479,12 @@ msgstr "KDSKBENT: %s: không thể giải cấp phát hay xóa sạch ánh xạ 
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: không thể trở về chế độ bàn phím gốc"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "gặp lỗi khi ràng buộc chuỗi “%s” với hàm %s"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "gặp lỗi khi xóa sạch chuỗi %s"
@@ -488,7 +493,7 @@ msgstr "gặp lỗi khi xóa sạch chuỗi %s"
 msgid "too many compose definitions"
 msgstr "quá nhiều định nghĩa cấu tạo"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -500,19 +505,19 @@ msgstr[0] ""
 "\n"
 "Đã thay đổi %d chuỗi"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] "Đã thay đổi %d chuỗi"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "Đã tảo %d định nghĩa tổ hợp"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(Chưa sửa đổi phần định nghĩa cấu tạo)"
 
@@ -581,7 +586,7 @@ msgstr ""
 "\n"
 "Nhận ra tên bộ điều chỉnh và số cột của chúng:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -626,18 +631,13 @@ msgstr ""
 "  -v --verbose       thông báo các thay đổi\n"
 "  -V --version       hiển thị số hiệu phiên bản\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s từ %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr ""
 "%s: Hai tùy chọn --unicode và --ascii xung đột với nhau, chỉ được dùng một\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -647,7 +647,7 @@ msgstr ""
 "khiển Unicode\n"
 "    (có lẽ bạn ý bạn muốn làm là “kbd_mode -a” phải không?)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -657,17 +657,17 @@ msgstr ""
 "không phải Unicode\n"
 "    (có lẽ bạn muốn làm là “kbd_mode -u” phải không?)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "Không tìm thấy %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "không mở được tập tin %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -676,28 +676,28 @@ msgstr ""
 "Cách dùng:\n"
 "\t%s [-C thiết bị điều khiển] [-o ánh-xạ.gốc]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "Dòng nhập vào sai: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: số glyph (0x%x) lớn hơn chiều dài phông chữ\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: Kết thúc của phạm vi sai (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr ""
 "%s: Phạm vi Unicode tương ứng với phạm vi vị trí phông chữ 0x%x-0x%x sai\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -706,22 +706,22 @@ msgstr ""
 "%s: Phạm vi Unicode U+%x-U+%x không có cũng chiều dài với phạm vi vị trí "
 "phông chữ 0x%x-0x%x\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: lờ đi khúc theo sau (%s)\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "Nạp ánh xạ unicode từ tập tin %s\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: Cảnh báo: dòng quá dài\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -730,87 +730,87 @@ msgstr ""
 "%s: không nạp ánh xạ unicode (unimap) rỗng\n"
 "(nếu bạn nhất định muốn: hãy sử dụng tùy chọn -f để thỏa mãn)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "mục"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "các mục"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Ghi ánh xạ unicode trên “%s”\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Nhập thêm ánh xạ Unicode\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "Cách dùng: %s [-V] [-v] [-o ánh-xạ.gốc] tập-tin-ánh-xạ\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: không thể mở tập tin ánh xạ _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "Không thể lấy được trạng thái (stat) tập tin bản đồ (map)"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr ""
 "Nạp ánh xạ màn hình (screen map) nhị phân thẳng tới phông (direct-to-font) "
 "từ tập tin %s\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "Lỗi đọc ánh xạ từ tập tin “%s”\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "Nạp ánh xạ màn hình (screen map) unicode nhị phân từ tập tin %s\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "Nạp ánh xạ màn hình (screen map) ký hiệu từ tập tin %s\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "Lỗi phân tích ánh xạ ký hiệu từ “%s”, dòng %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "Lỗi ghi nhớ ánh xạ vào tập tin\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "Không đọc được ánh xạ thiết bị điều khiển (console map)\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "Ghi nhớ ánh xạ màn hình (screen map) trong “%s”\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -843,11 +843,11 @@ msgstr ""
 "  -h, --help          hiển thị thông tin trợ giúp ở dạng ngắn gọn.\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "không tìm thấy người sở hữu tty đang dùng!"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: Số vt không hợp lệ"
@@ -897,96 +897,96 @@ msgstr "Đang dùng VT %s"
 msgid "Cannot open %s read/write"
 msgstr "không thể mở %s để đọc/ghi"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "Không thể kích hoạt vt %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "Kích hoạt bị ngắt phải không?"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "Không thể cấp phát lại console (thiết bị điều khiển) %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: bảng unicode ucs2 ngắn\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: bảng unicode utf8 ngắn\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: utf8 sai\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: lỗi utf8 không rõ\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: bảng unicode ngắn\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: Lỗi đọc phông chữ nhập vào"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: Lời gọi readpsffont sai\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: Chế độ tập tin psf (%d) không được hỗ trợ\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: phiên bản psf (%d) không được hỗ trợ\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: chiều dài phông chữ nhập vào bằng không?\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: kích thước ký tự nhập vào bằng không?\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: Tập tin nhập vào: chiều dài nhập vào sai (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: Tập tin nhập vào: vết rác\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: unicode không đúng %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "Không thể ghi nhớ phần đầu (header) tập tin phông chữ"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "Không thể ghi tập tin phông chữ"
@@ -1071,31 +1071,41 @@ msgstr "%s: tập tin psf với số màu nhiệm không rõ\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: phông nhập vào không có một chỉ mục\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: không tìm thấy tập tin chế độ video %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: không tìm thấy tập tin chế độ video %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "Số dòng không đúng\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "Chế độ cũ: %dx%d  Chế độ mới: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "#scanlines Cũ:  %d  #scanlines Mới: %d  Chiều cao ký tự : %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: câu lệnh “%s” bị lỗi\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
@@ -1103,7 +1113,7 @@ msgstr ""
 "resizecons: đừng quên thay đổi TERM (có thể thành con%dx%d hoặc linux-%dx"
 "%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1116,41 +1126,41 @@ msgstr ""
 "hoặc: resizecons -lines ROWS, với ROWS là một trong số 25, 28, 30, 34, 36, "
 "40, 44, 50, 60\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: không lấy được quyền I/O.\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "cách dùng: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "Lỗi đọc %s"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "không thể đọc %s, và không thể ioctl dump\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "không thể đọc %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "Kỳ lạ … màn hình là cả %dx%d và %dx%d ??\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "Gặp lỗi khi ghi đổ màn hình\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1205,12 +1215,12 @@ msgstr ""
 "    -V         In ra số hiệu phiên bản và thoát.\n"
 "Tập tin được nạp từ thư mục hiện tại hoặc từ %s/*/.\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: quá nhiều tập tin đầu vào\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
@@ -1219,123 +1229,123 @@ msgstr ""
 "setfont: không thể đồng thời phục hồi từ ký tự ROM và từ tập tin. Phông chữ "
 "không thay đổi.\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "Chiều cao ký tự %d sai\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "Chiều rộng ký tự %d sai\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: vị trí phông chữ 32 không trống\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: tẩy nó\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: phông nền trông buồn cười\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "Nạp %d-char %dx%d phông từ tập tin %s\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "Nạp %d-char %dx%d phông\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "Nạp %d-char %dx%d (%d) phông từ tập tin %s\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "Nạp %d-char %dx%d (%d) phông\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: lỗi (bug) trong do_loadtable\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "Đang nạp bảng ánh xạ Unicode…\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "Không mở được tập tin phông chữ %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr ""
 "Khi nạp vài phông chữ, tất cả phải là phông psf - nhưng %s không phải\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "Đọc %d-char %dx%d phông từ tập tin %s\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "Khi nạp vài phông chữ, tất cả phải có cùng chiều cao\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "Khi nạp vài phông chữ, tất cả phải có cùng chiều rộng\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "Không tìm thấy phông mặc định\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "Không tìm thấy phông %s\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "Đang đọc tập tin phông chữ %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "Không có dòng mới cuối cùng trong liên hợp tập tin\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "Quá nhiều tập tin trong liên hợp\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "Hừm - một phông chữ từ phông phục hồi? Sử dụng nửa đầu tiên.\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "Kích thước tập tin nhập vào sai\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1344,23 +1354,23 @@ msgstr ""
 "Tập tin này chứa 3 phông chữ: 8x8, 8x14 và 8x16. Xin hãy cho biết\n"
 "phông bạn muốn nạp bằng một tùy chọn -8 hoặc -14 hoặc -16.\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr ""
 "Bạn yêu cầu kích thước phông chữ %d, nhưng chỉ có kích thước 8, 14 và 16.\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "Khôg tìm thấy gì để ghi nhớ\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "Ghi nhớ %d-char %dx%d tập tin phông chữ trên%s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1371,19 +1381,19 @@ msgstr ""
 " (trong đó scancode là xx hoặc e0xx, ở dạng hệ mười sáu,\n"
 "  còn keycode ở dạng hệ mười)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "mong đợi một tham số số chẵn"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "lỗi đọc mã quét (scancode)"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "mã nằm ngoài khung giới hạn"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr ""
@@ -1563,12 +1573,12 @@ msgstr "trạng thái cũ: "
 msgid "new state:    "
 msgstr "trạng thái mới: "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "cách dùng: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1604,39 +1614,39 @@ msgstr ""
 "   -V     in số hiệu phiên bản\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "Lỗi: %s: Giá trị không hợp lện trong trường %u tại dòng %u."
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "Lỗi: %s: Số lượng trường bị thiếu tại dòng %u."
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "Lỗi: %s: Dòng %u bị chấm dứt bất ngờ.\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "Lỗi: %s: Dòng %u quá đài.\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "phục hồi bảng dịch thuật gốc không thành công\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "phục hồi ánh xạ unicode (unimap) gốc không thành công\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "không thể thay đổi bảng dịch thuật\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1685,16 +1695,16 @@ msgstr ""
 "Đang hiển thị phông chữ %d-ký-tự\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?KHÔNG RÕ?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "chế độ bàn phím từng là %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1703,12 +1713,12 @@ msgstr ""
 "[ nếu bạn chạy lệnh này dưới X, có thể nó không làm việc\n"
 "vì máy chủ X cũng đọc /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "nhận được tín hiệu %d, đang dọn dẹp…\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, c-format
 msgid ""
 "showkey version %s\n"
@@ -1765,11 +1775,11 @@ msgstr "nhấn"
 msgid "keycode %3d %s\n"
 msgstr "mã phím (keycode) %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "cách dùng: totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1779,18 +1789,18 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr ""
 "Bộ hiển thị toàn bộ bảng điều khiển hiện nay được khóa hoàn toàn bởi %s.\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "“%s” bị khóa bởi %s.\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr "Dùng các phím Alt-function để chuyển bảng điều khiển ảo khác."
 
@@ -1799,7 +1809,7 @@ msgstr "Dùng các phím Alt-function để chuyển bảng điều khiển ảo
 msgid "Try `%s --help' for more information.\n"
 msgstr "Hãy gõ lệnh “%s --help” để xem thông tin thêm.\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1828,16 +1838,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "không nhận ra người dùng"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "stdin không phải là một tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "tty này (%s) không phải là bảng điều khiển ảo.\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "Toàn bộ phần trình bày bảng điều khiển không thể bị khóa.\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kbd 2.0.3-rc1\n"
 "Report-Msgid-Bugs-To: Alexey Gladkov <gladkov.alexey@gmail.com>\n"
-"POT-Creation-Date: 2016-12-26 17:38+0100\n"
+"POT-Creation-Date: 2018-06-29 18:31+0100\n"
 "PO-Revision-Date: 2015-11-03 10:39-0500\n"
 "Last-Translator: Mingye Wang (Arthur2e5) <arthur200126@gmail.com>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -21,45 +21,45 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.8.6\n"
 
-#: src/chvt.c:32
+#: src/chvt.c:31
 #, c-format
 msgid "usage: chvt N\n"
 msgstr "用法: chvt N\n"
 
-#: src/chvt.c:37 src/clrunimap.c:30 src/deallocvt.c:43 src/dumpkeys.c:158
-#: src/fgconsole.c:69 src/getkeycodes.c:45 src/getunimap.c:73 src/kbdinfo.c:81
-#: src/kbd_mode.c:79 src/loadkeys.c:179 src/loadunimap.c:84 src/mapscrn.c:60
-#: src/openvt.c:258 src/resizecons.c:153 src/setfont.c:195 src/setkeycodes.c:51
-#: src/setlogcons.c:37 src/setpalette.c:36 src/setvesablank.c:33
-#: src/setvtrgb.c:140 src/showconsolefont.c:152 src/showkey.c:189
-#: src/totextmode.c:37
+#: src/chvt.c:36 src/clrunimap.c:32 src/deallocvt.c:42 src/dumpkeys.c:157
+#: src/fgconsole.c:68 src/getkeycodes.c:44 src/getunimap.c:72 src/kbdinfo.c:81
+#: src/kbd_mode.c:78 src/loadkeys.c:174 src/loadunimap.c:83 src/mapscrn.c:58
+#: src/openvt.c:258 src/resizecons.c:171 src/setfont.c:194 src/setkeycodes.c:50
+#: src/setlogcons.c:38 src/setpalette.c:35 src/setvesablank.c:34
+#: src/setvtrgb.c:139 src/showconsolefont.c:152 src/showkey.c:189
+#: src/totextmode.c:35
 msgid "Couldn't get a file descriptor referring to the console"
 msgstr "无法获取指向控制台的文件描述符"
 
-#: src/deallocvt.c:37
+#: src/deallocvt.c:36
 #, c-format
 msgid "%s: unknown option\n"
 msgstr "%s: 未知的选项\n"
 
-#: src/deallocvt.c:54
+#: src/deallocvt.c:53
 msgid "0: illegal VT number\n"
 msgstr "0: 非法的 VT 号\n"
 
-#: src/deallocvt.c:56
+#: src/deallocvt.c:55
 msgid "VT 1 is the console and cannot be deallocated\n"
 msgstr "VT 1 是控制台并且无法被回收\n"
 
-#: src/deallocvt.c:58
+#: src/deallocvt.c:57
 #, c-format
 msgid "could not deallocate console %d: ioctl VT_DISALLOCATE"
 msgstr "无法回收控制台 %d: ioctl VT_DISALLOCATE"
 
-#: src/dumpkeys.c:31
+#: src/dumpkeys.c:29
 #, c-format
 msgid "dumpkeys version %s"
 msgstr "dumpkeys 版本 %s"
 
-#: src/dumpkeys.c:32
+#: src/dumpkeys.c:30
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -95,7 +95,7 @@ msgstr ""
 "\t   --compose-only    只显示组合键\n"
 "\t-c --charset="
 
-#: src/dumpkeys.c:50
+#: src/dumpkeys.c:48
 #, c-format
 msgid ""
 "\t\t\t    interpret character action codes to be from the\n"
@@ -104,24 +104,24 @@ msgstr ""
 "\t\t\t    解释来自指定字符集的\n"
 "\t\t\t    字符动作代码\n"
 
-#: src/dumpkeys.c:54
+#: src/dumpkeys.c:52
 #, c-format
 msgid ""
 "\t-v --verbose\n"
 "\t-V --version\t    print version number\n"
 msgstr ""
 
-#: src/dumpkeys.c:140
+#: src/dumpkeys.c:138
 #, c-format
 msgid "unknown charset %s - ignoring charset request\n"
 msgstr "未知的字符集 %s - 忽略字符集请求\n"
 
-#: src/dumpkeys.c:162 src/loadkeys.c:184
+#: src/dumpkeys.c:161 src/loadkeys.c:179
 #, c-format
 msgid "%s: error reading keyboard mode: %m\n"
 msgstr "%s: 设置键盘模式出错: %m\n"
 
-#: src/dumpkeys.c:178
+#: src/dumpkeys.c:177
 #, c-format
 msgid ""
 "Symbols recognized by %s:\n"
@@ -132,7 +132,7 @@ msgstr ""
 "(数值, 标志)\n"
 "\n"
 
-#: src/fgconsole.c:21
+#: src/fgconsole.c:20
 #, c-format
 msgid ""
 "%s version %s\n"
@@ -155,41 +155,31 @@ msgstr ""
 "\t-V --version         显示程序版本\n"
 "\t-n --next-available  显示下一个未被分配的 VT 编号\n"
 
-#: src/fgconsole.c:73
+#: src/fgconsole.c:72
 msgid "Couldn't read VTNO: "
 msgstr "无法读取 VT 号:"
 
-#: src/getfd.c:69
-#, c-format
-msgid "Couldn't open %s\n"
-msgstr "无法打开 %s\n"
-
-#: src/getfd.c:86
-#, c-format
-msgid "Couldn't get a file descriptor referring to the console\n"
-msgstr "无法获取指向控制台的文件描述符\n"
-
-#: src/getkeycodes.c:22
+#: src/getkeycodes.c:21
 #, c-format
 msgid "usage: getkeycodes\n"
 msgstr "用法: getkeycodes\n"
 
-#: src/getkeycodes.c:60
+#: src/getkeycodes.c:59
 #, c-format
 msgid "Plain scancodes xx (hex) versus keycodes (dec)\n"
 msgstr "普通扫描码 xx (十六进制) 对应键码(十进制)\n"
 
-#: src/getkeycodes.c:63
+#: src/getkeycodes.c:62
 #, c-format
 msgid "0 is an error; for 1-88 (0x01-0x58) scancode equals keycode\n"
 msgstr "0 是一个错误；对于等于扫描码 1-88 (0x01-0x58) 的键码来说\n"
 
-#: src/getkeycodes.c:66
+#: src/getkeycodes.c:65
 #, c-format
 msgid "for 1-%d (0x01-0x%02x) scancode equals keycode\n"
 msgstr "对于 1-%d (0x01-0x%02x) 的扫描码等于键码\n"
 
-#: src/getkeycodes.c:72
+#: src/getkeycodes.c:71
 #, c-format
 msgid ""
 "\n"
@@ -200,12 +190,12 @@ msgstr ""
 "\n"
 "跳过扫描码 e0 xx (十六进制)\n"
 
-#: src/getkeycodes.c:95
+#: src/getkeycodes.c:94
 #, c-format
 msgid "failed to get keycode for scancode 0x%x: ioctl KDGETKEYCODE"
 msgstr "获取扫描码 0x%x 的键码失败: ioctl KDGETKEYCODE"
 
-#: src/getunimap.c:33
+#: src/getunimap.c:32
 #, c-format
 msgid ""
 "Usage:\n"
@@ -241,71 +231,71 @@ msgstr ""
 "错误：无法识别的动作: _%s_\n"
 "\n"
 
-#: src/kbd_mode.c:24
+#: src/kbd_mode.c:23
 #, c-format
 msgid "usage: kbd_mode [-a|-u|-k|-s] [-C device]\n"
 msgstr "用法: kbd_mode [-a|-u|-k|-s] [-C 设备]\n"
 
-#: src/kbd_mode.c:88
+#: src/kbd_mode.c:87
 #, c-format
 msgid "The keyboard is in raw (scancode) mode\n"
 msgstr "键盘处于原始(扫描码)模式\n"
 
-#: src/kbd_mode.c:91
+#: src/kbd_mode.c:90
 #, c-format
 msgid "The keyboard is in mediumraw (keycode) mode\n"
 msgstr "键盘处于半原始(键码)模式\n"
 
-#: src/kbd_mode.c:94
+#: src/kbd_mode.c:93
 #, c-format
 msgid "The keyboard is in the default (ASCII) mode\n"
 msgstr "键盘处于默认 (ASCII) 模式\n"
 
-#: src/kbd_mode.c:97
+#: src/kbd_mode.c:96
 #, c-format
 msgid "The keyboard is in Unicode (UTF-8) mode\n"
 msgstr "键盘处于 Unicode (UTF-8) 模式\n"
 
-#: src/kbd_mode.c:100
+#: src/kbd_mode.c:99
 #, c-format
 msgid "The keyboard is in some unknown mode\n"
 msgstr "键盘处于某种未知模式\n"
 
-#: src/kbdrate.c:157 src/kbdrate.c:175 src/kbdrate.c:332
+#: src/kbdrate.c:156 src/kbdrate.c:174 src/kbdrate.c:330
 #, c-format
 msgid "Typematic Rate set to %.1f cps (delay = %d ms)\n"
 msgstr "字元输入速率设置为 %.1f cps (延迟 = %d ms)\n"
 
-#: src/kbdrate.c:267
+#: src/kbdrate.c:265
 #, fuzzy, c-format
 msgid "Usage: kbdrate [-V | --version] [-s] [-r rate] [-d delay]\n"
 msgstr "用法: kbdrate [-V] [-s] [-r 速率] [-d 延迟]\n"
 
-#: src/kbdrate.c:295
+#: src/kbdrate.c:293
 msgid "Cannot open /dev/port"
 msgstr "无法打开 /dev/port"
 
-#: src/kdfontop.c:97
+#: src/kdfontop.c:98
 #, c-format
 msgid "bug: getfont called with count<256\n"
 msgstr "程序错误: 调用 getfont 时 count<256\n"
 
-#: src/kdfontop.c:101
+#: src/kdfontop.c:102
 #, c-format
 msgid "bug: getfont using GIO_FONT needs buf.\n"
 msgstr "程序错误: 使用 GIO_FONT 时 getfont 需要 buf.\n"
 
-#: src/kdfontop.c:158 src/kdmapop.c:152 src/xmalloc.c:18
+#: src/kdfontop.c:159 src/kdmapop.c:153 src/libcommon/xmalloc.c:18
 #, c-format
 msgid "%s: out of memory\n"
 msgstr "%s: 内存不足\n"
 
-#: src/kdmapop.c:161
+#: src/kdmapop.c:162
 #, c-format
 msgid "strange... ct changed from %d to %d\n"
 msgstr "奇怪...ct 从 %d 变成了 %d。\n"
 
-#: src/kdmapop.c:187
+#: src/kdmapop.c:188
 #, c-format
 msgid ""
 "It seems this kernel is older than 1.1.92\n"
@@ -314,21 +304,36 @@ msgstr ""
 "看来这个内核比 1.1.92 旧。\n"
 "未加载任何 Unicode 映射表。\n"
 
-#: src/libkeymap/common.c:140 src/libkeymap/kmap.c:58 src/libkeymap/kmap.c:66
+#: src/libcommon/getfd.c:69
+#, c-format
+msgid "Couldn't open %s\n"
+msgstr "无法打开 %s\n"
+
+#: src/libcommon/getfd.c:86
+#, c-format
+msgid "Couldn't get a file descriptor referring to the console\n"
+msgstr "无法获取指向控制台的文件描述符\n"
+
+#: src/libcommon/version.c:29
+#, c-format
+msgid "%s from %s\n"
+msgstr "%s 来自 %s\n"
+
+#: src/libkeymap/common.c:135 src/libkeymap/kmap.c:61 src/libkeymap/kmap.c:69
 #: src/libkeymap/loadkeys.c:120
 msgid "out of memory"
 msgstr "%内存不足"
 
-#: src/libkeymap/common.c:146
+#: src/libkeymap/common.c:141
 #, c-format
 msgid "unable to initialize array: %s"
 msgstr "无法初始化数组: %s"
 
-#: src/libkeymap/dump.c:86
+#: src/libkeymap/dump.c:87
 msgid "Error writing map to file"
 msgstr "将映射写入文件失败"
 
-#: src/libkeymap/dump.c:542
+#: src/libkeymap/dump.c:545
 #, c-format
 msgid "impossible: not meta?\n"
 msgstr "不可能:不是 meta 键?\n"
@@ -348,71 +353,71 @@ msgstr "KDGKBSENT: %s: 无法获取功能键字符串"
 msgid "KDGKBDIACR(UC): %s: Unable to get accent table"
 msgstr "KDGKBDIACR(UC): %s: 无法获取重音字符表"
 
-#: src/libkeymap/kmap.c:80 src/libkeymap/kmap.c:98
+#: src/libkeymap/kmap.c:83 src/libkeymap/kmap.c:101
 #, c-format
 msgid "unable to get keymap %d"
 msgstr "无法获取键映射 %d"
 
-#: src/libkeymap/kmap.c:106
+#: src/libkeymap/kmap.c:109
 #, c-format
 msgid "unable to unset key %d for table %d"
 msgstr "将键 %d 取消绑定到表 %d 失败"
 
-#: src/libkeymap/kmap.c:122
+#: src/libkeymap/kmap.c:125
 #, c-format
 msgid "lk_add_key called with bad keycode %d"
 msgstr "调用 lk_add_key 时使用了错误的键码 %d"
 
-#: src/libkeymap/kmap.c:129
+#: src/libkeymap/kmap.c:132
 #, c-format
 msgid "adding map %d violates explicit keymaps line"
 msgstr "添加映射 %d 违反了显式键映射行"
 
-#: src/libkeymap/kmap.c:145
+#: src/libkeymap/kmap.c:148
 #, c-format
 msgid "unable to set key %d for table %d"
 msgstr "将键 %d 绑定到表 %d 失败"
 
-#: src/libkeymap/kmap.c:236
+#: src/libkeymap/kmap.c:239
 msgid "impossible error in lk_add_constants"
 msgstr "lk_add_constants 中发生不可能的错误"
 
-#: src/libkeymap/ksyms.c:150
+#: src/libkeymap/ksyms.c:151
 #, c-format
 msgid "unable to get symbol by wrong type: %d"
 msgstr "无法以错误的类型获取符号: %d"
 
-#: src/libkeymap/ksyms.c:164
+#: src/libkeymap/ksyms.c:165
 #, c-format
 msgid "unable to get symbol of %d type by wrong index: %d"
 msgstr "无法以错误的索引获取 %d 类型的符号: %d"
 
-#: src/libkeymap/ksyms.c:339
+#: src/libkeymap/ksyms.c:340
 #, c-format
 msgid "assuming iso-8859-1 %s"
 msgstr "假定 iso-8859-1 %s"
 
-#: src/libkeymap/ksyms.c:345
+#: src/libkeymap/ksyms.c:346
 #, c-format
 msgid "assuming iso-8859-15 %s"
 msgstr "假定 iso-8859-15 %s"
 
-#: src/libkeymap/ksyms.c:351
+#: src/libkeymap/ksyms.c:352
 #, c-format
 msgid "assuming iso-8859-2 %s"
 msgstr "假定 iso-8859-2 %s"
 
-#: src/libkeymap/ksyms.c:357
+#: src/libkeymap/ksyms.c:358
 #, c-format
 msgid "assuming iso-8859-3 %s"
 msgstr "假定 iso-8859-3 %s"
 
-#: src/libkeymap/ksyms.c:363
+#: src/libkeymap/ksyms.c:364
 #, c-format
 msgid "assuming iso-8859-4 %s"
 msgstr " iso-8859-4 %s"
 
-#: src/libkeymap/ksyms.c:368
+#: src/libkeymap/ksyms.c:369
 #, c-format
 msgid "unknown keysym '%s'\n"
 msgstr "未知的 keysym '%s'\n"
@@ -461,12 +466,12 @@ msgstr "KDSKBENT: %s: 无法回收或清除键映射"
 msgid "KDSKBMODE: %s: could not return to original keyboard mode"
 msgstr "KDSKBMODE: %s: 无法回到原来的键盘模式"
 
-#: src/libkeymap/loadkeys.c:163
+#: src/libkeymap/loadkeys.c:164
 #, c-format
 msgid "failed to bind string '%s' to function %s"
 msgstr "将字符串 '%s' 绑定到函数 %s 失败"
 
-#: src/libkeymap/loadkeys.c:173
+#: src/libkeymap/loadkeys.c:174
 #, c-format
 msgid "failed to clear string %s"
 msgstr "清除字符串 %s 失败"
@@ -475,7 +480,7 @@ msgstr "清除字符串 %s 失败"
 msgid "too many compose definitions"
 msgstr "太多组合定义"
 
-#: src/libkeymap/loadkeys.c:252
+#: src/libkeymap/loadkeys.c:254
 #, c-format
 msgid ""
 "\n"
@@ -487,19 +492,19 @@ msgstr[0] ""
 "\n"
 "更改了 %d 个键"
 
-#: src/libkeymap/loadkeys.c:253
+#: src/libkeymap/loadkeys.c:255
 #, c-format
 msgid "Changed %d string"
 msgid_plural "Changed %d strings"
 msgstr[0] "已修改 %d 个字符串"
 
-#: src/libkeymap/loadkeys.c:261
+#: src/libkeymap/loadkeys.c:263
 #, c-format
 msgid "Loaded %d compose definition"
 msgid_plural "Loaded %d compose definitions"
 msgstr[0] "加载了 %d 个组合定义"
 
-#: src/libkeymap/loadkeys.c:266
+#: src/libkeymap/loadkeys.c:268
 msgid "(No change in compose definitions)"
 msgstr "(组合定义没有改变)"
 
@@ -568,7 +573,7 @@ msgstr ""
 "\n"
 "已被识别的修饰符名称和它们的列号:\n"
 
-#: src/loadkeys.c:36
+#: src/loadkeys.c:32
 #, fuzzy, c-format
 msgid ""
 "loadkeys version %s\n"
@@ -610,17 +615,12 @@ msgstr ""
 "  -u --unicode       隐式转换为 Unicode\n"
 "  -v --verbose       报告任何改变\n"
 
-#: src/loadkeys.c:161 src/version.h:22
-#, c-format
-msgid "%s from %s\n"
-msgstr "%s 来自 %s\n"
-
-#: src/loadkeys.c:171
+#: src/loadkeys.c:166
 #, c-format
 msgid "%s: Options --unicode and --ascii are mutually exclusive\n"
 msgstr "%s: 选项 --unicode 和 --ascii 互斥\n"
 
-#: src/loadkeys.c:192
+#: src/loadkeys.c:187
 #, c-format
 msgid ""
 "%s: warning: loading non-Unicode keymap on Unicode console\n"
@@ -629,7 +629,7 @@ msgstr ""
 "%s: 警告：正在 Unicode 终端上加载非 Unicode 键映射\n"
 "    (或许你想 `kbd_mode -u'？)\n"
 
-#: src/loadkeys.c:204
+#: src/loadkeys.c:199
 #, c-format
 msgid ""
 "%s: warning: loading Unicode keymap on non-Unicode console\n"
@@ -638,17 +638,17 @@ msgstr ""
 "%s: 警告：正在非 Unicode 终端上加载 Unicode 键映射\n"
 "    (或许你想 `kbd_mode -u'？)\n"
 
-#: src/loadkeys.c:222
+#: src/loadkeys.c:217
 #, c-format
 msgid "Cannot find %s\n"
 msgstr "无法找到 %s\n"
 
-#: src/loadkeys.c:243
+#: src/loadkeys.c:238
 #, c-format
 msgid "cannot open file %s\n"
 msgstr "无法打开文件 %s\n"
 
-#: src/loadunimap.c:46
+#: src/loadunimap.c:45
 #, c-format
 msgid ""
 "Usage:\n"
@@ -657,27 +657,27 @@ msgstr ""
 "用法:\n"
 "\t%s [-C 控制台] [-o 原始映射]\n"
 
-#: src/loadunimap.c:182 src/loadunimap.c:193
+#: src/loadunimap.c:181 src/loadunimap.c:192
 #, c-format
 msgid "Bad input line: %s\n"
 msgstr "错误的输入行: %s\n"
 
-#: src/loadunimap.c:202
+#: src/loadunimap.c:201
 #, c-format
 msgid "%s: Glyph number (0x%x) larger than font length\n"
 msgstr "%s: 符号编号 (0x%x) 大于字体长度\n"
 
-#: src/loadunimap.c:208
+#: src/loadunimap.c:207
 #, c-format
 msgid "%s: Bad end of range (0x%x)\n"
 msgstr "%s: 错误的范围结束值 (0x%x)\n"
 
-#: src/loadunimap.c:238 src/psfxtable.c:180
+#: src/loadunimap.c:237 src/psfxtable.c:180
 #, c-format
 msgid "%s: Bad Unicode range corresponding to font position range 0x%x-0x%x\n"
 msgstr "%s: 错误的 Unicode 范围对应于字体位置范围 0x%x-0x%x\n"
 
-#: src/loadunimap.c:245 src/psfxtable.c:187
+#: src/loadunimap.c:244 src/psfxtable.c:187
 #, c-format
 msgid ""
 "%s: Unicode range U+%x-U+%x not of the same length as font position range 0x"
@@ -685,22 +685,22 @@ msgid ""
 msgstr ""
 "%s: Unicode 范围 U+%x-U+%x 的长度和字体位置范围 0x%x-0x%x 的长度不一致\n"
 
-#: src/loadunimap.c:264 src/psfxtable.c:208
+#: src/loadunimap.c:263 src/psfxtable.c:208
 #, c-format
 msgid "%s: trailing junk (%s) ignored\n"
 msgstr "%s: 尾部无用信息 (%s) 被忽略\n"
 
-#: src/loadunimap.c:280
+#: src/loadunimap.c:286
 #, c-format
 msgid "Loading unicode map from file %s\n"
 msgstr "正在从文件 %s 加载 unicode 映射\n"
 
-#: src/loadunimap.c:286
+#: src/loadunimap.c:292
 #, c-format
 msgid "%s: %s: Warning: line too long\n"
 msgstr "%s: %s: 警告: 行太长\n"
 
-#: src/loadunimap.c:296
+#: src/loadunimap.c:303
 #, c-format
 msgid ""
 "%s: not loading empty unimap\n"
@@ -709,85 +709,85 @@ msgstr ""
 "%s: 无法加载空的 unimap\n"
 "(如果你坚持: 使用选项 -f 来覆盖)\n"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entry"
 msgstr "个条目"
 
-#: src/loadunimap.c:318
+#: src/loadunimap.c:323
 msgid "entries"
 msgstr "个条目"
 
-#: src/loadunimap.c:344
+#: src/loadunimap.c:350
 #, c-format
 msgid "Saved unicode map on `%s'\n"
 msgstr "Unicode 映射已保存到文件 '%s'\n"
 
-#: src/loadunimap.c:380
+#: src/loadunimap.c:388
 #, c-format
 msgid "Appended Unicode map\n"
 msgstr "Unicode 映射已附加\n"
 
-#: src/mapscrn.c:71
+#: src/mapscrn.c:69
 #, fuzzy, c-format
 msgid "usage: %s [-V] [-v] [-o map.orig] map-file\n"
 msgstr "用法: %s [-v] [-o 原始映射] 映射文件\n"
 
-#: src/mapscrn.c:138
+#: src/mapscrn.c:143
 #, c-format
 msgid "mapscrn: cannot open map file _%s_\n"
 msgstr "mapscrn: 无法打开映射文件 _%s_\n"
 
-#: src/mapscrn.c:144
+#: src/mapscrn.c:149
 #, c-format
 msgid "Cannot stat map file"
 msgstr "无法 stat 映射文件"
 
-#: src/mapscrn.c:149
+#: src/mapscrn.c:154
 #, c-format
 msgid "Loading binary direct-to-font screen map from file %s\n"
 msgstr "正在从文件 %s 加载二进制 direct-to-font 屏幕映射\n"
 
-#: src/mapscrn.c:154 src/mapscrn.c:165
+#: src/mapscrn.c:159 src/mapscrn.c:170
 #, c-format
 msgid "Error reading map from file `%s'\n"
 msgstr "从文件 '%s' 读取映射出错\n"
 
-#: src/mapscrn.c:160
+#: src/mapscrn.c:165
 #, c-format
 msgid "Loading binary unicode screen map from file %s\n"
 msgstr "正在从文件 %s 加载二进制 unicode 屏幕映射\n"
 
-#: src/mapscrn.c:172
+#: src/mapscrn.c:177
 #, c-format
 msgid "Loading symbolic screen map from file %s\n"
 msgstr "正在从文件 %s 加载符号屏幕映射\n"
 
-#: src/mapscrn.c:176
+#: src/mapscrn.c:181
 #, c-format
 msgid "Error parsing symbolic map from `%s', line %d\n"
 msgstr "从文件 '%s' 解析标志映射出错，行 %d\n"
 
-#: src/mapscrn.c:281 src/mapscrn.c:286
+#: src/mapscrn.c:287 src/mapscrn.c:292
 #, c-format
 msgid "Error writing map to file\n"
 msgstr "将映射写入文件失败\n"
 
-#: src/mapscrn.c:290
+#: src/mapscrn.c:296
 #, c-format
 msgid "Cannot read console map\n"
 msgstr "无法读取控制台映射\n"
 
-#: src/mapscrn.c:296
+#: src/mapscrn.c:302
 #, c-format
 msgid "Saved screen map in `%s'\n"
 msgstr "屏幕映射已保存到 '%s'\n"
 
-#: src/openvt.c:49
-#, c-format
+#: src/openvt.c:48
+#, fuzzy, c-format
 msgid ""
 "Usage: %s [OPTIONS] -- command\n"
 "\n"
-"This utility help you to start a program on a new virtual terminal (VT).\n"
+"This utility helps you to start a program on a new virtual terminal (VT).\n"
 "\n"
 "Options:\n"
 "  -c, --console=NUM   use the given VT number;\n"
@@ -819,11 +819,11 @@ msgstr ""
 "  -h, --help          输出简短的帮助信息\n"
 "\n"
 
-#: src/openvt.c:141
+#: src/openvt.c:140
 msgid "Couldn't find owner of current tty!"
 msgstr "无法找到当前 tty 的所有者！"
 
-#: src/openvt.c:210
+#: src/openvt.c:209
 #, c-format
 msgid "%s: Illegal vt number"
 msgstr "%s: 非法的 VT 号"
@@ -869,96 +869,96 @@ msgstr "正在使用 VT %s"
 msgid "Cannot open %s read/write"
 msgstr "无法打开 %s 以供读写"
 
-#: src/openvt.c:360
+#: src/openvt.c:361
 #, c-format
 msgid "Couldn't activate vt %d"
 msgstr "无法激活 VT %d"
 
-#: src/openvt.c:363
+#: src/openvt.c:364
 msgid "Activation interrupted?"
 msgstr "激活被中断？"
 
-#: src/openvt.c:403
+#: src/openvt.c:404
 #, c-format
 msgid "Couldn't deallocate console %d"
 msgstr "无法回收控制台 %d"
 
-#: src/psffontop.c:76
+#: src/psffontop.c:75
 #, c-format
 msgid "%s: short ucs2 unicode table\n"
 msgstr "%s: 短 ucs2 unicode 表\n"
 
-#: src/psffontop.c:98
+#: src/psffontop.c:97
 #, c-format
 msgid "%s: short utf8 unicode table\n"
 msgstr "%s: 短 utf8 unicode 表\n"
 
-#: src/psffontop.c:101
+#: src/psffontop.c:100
 #, c-format
 msgid "%s: bad utf8\n"
 msgstr "%s: 错误的 utf8\n"
 
-#: src/psffontop.c:104
+#: src/psffontop.c:103
 #, c-format
 msgid "%s: unknown utf8 error\n"
 msgstr "%s: 未知的 utf8 错误\n"
 
-#: src/psffontop.c:136
+#: src/psffontop.c:135
 #, c-format
 msgid "%s: short unicode table\n"
 msgstr "%s: 短 unicode 表\n"
 
-#: src/psffontop.c:216
+#: src/psffontop.c:215
 #, c-format
 msgid "%s: Error reading input font"
 msgstr "%s: 读取输入字体出错"
 
-#: src/psffontop.c:230
+#: src/psffontop.c:229
 #, c-format
 msgid "%s: Bad call of readpsffont\n"
 msgstr "%s: 对 readpsffont 的错误调用\n"
 
-#: src/psffontop.c:245
+#: src/psffontop.c:244
 #, c-format
 msgid "%s: Unsupported psf file mode (%d)\n"
 msgstr "%s: 不支持的 psf 文件模式 (%d)\n"
 
-#: src/psffontop.c:263
+#: src/psffontop.c:262
 #, c-format
 msgid "%s: Unsupported psf version (%d)\n"
 msgstr "%s: 不支持的 psf 版本 (%d)\n"
 
-#: src/psffontop.c:279
+#: src/psffontop.c:278
 #, c-format
 msgid "%s: zero input font length?\n"
 msgstr "%s: 输入字体的长度为 0？\n"
 
-#: src/psffontop.c:284
+#: src/psffontop.c:283
 #, c-format
 msgid "%s: zero input character size?\n"
 msgstr "%s: 输入字符的大小为 0？\n"
 
-#: src/psffontop.c:290
+#: src/psffontop.c:289
 #, c-format
 msgid "%s: Input file: bad input length (%d)\n"
 msgstr "%s: 输入文件: 错误的输入长度 (%d)\n"
 
-#: src/psffontop.c:322
+#: src/psffontop.c:321
 #, c-format
 msgid "%s: Input file: trailing garbage\n"
 msgstr "%s: 输入文件: 尾部无用信息\n"
 
-#: src/psffontop.c:361
+#: src/psffontop.c:360
 #, c-format
 msgid "appendunicode: illegal unicode %u\n"
 msgstr "appendunicode: 非法的 unicode %u\n"
 
-#: src/psffontop.c:455
+#: src/psffontop.c:454
 #, c-format
 msgid "Cannot write font file header"
 msgstr "无法写入字体文件头部"
 
-#: src/psffontop.c:480 src/setfont.c:693
+#: src/psffontop.c:479 src/setfont.c:717
 #, c-format
 msgid "Cannot write font file"
 msgstr "无法写入字体文件"
@@ -1041,37 +1041,47 @@ msgstr "%s: psf 文件使用了未知的魔数\n"
 msgid "%s: input font does not have an index\n"
 msgstr "%s: 输入字体没有索引\n"
 
-#: src/resizecons.c:147
+#: src/resizecons.c:146
+#, fuzzy, c-format
+msgid "resizecons: invalid columns number %d\n"
+msgstr "resizecons: 无法找到 videomode 文件 %s\n"
+
+#: src/resizecons.c:151
+#, c-format
+msgid "resizecons: invalid rows number %d\n"
+msgstr ""
+
+#: src/resizecons.c:165
 #, c-format
 msgid "resizecons: cannot find videomode file %s\n"
 msgstr "resizecons: 无法找到 videomode 文件 %s\n"
 
-#: src/resizecons.c:164
+#: src/resizecons.c:182
 msgid "Invalid number of lines\n"
 msgstr "非法的行数\n"
 
-#: src/resizecons.c:247
+#: src/resizecons.c:265
 #, c-format
 msgid "Old mode: %dx%d  New mode: %dx%d\n"
 msgstr "旧的模式: %dx%d 新的模式: %dx%d\n"
 
-#: src/resizecons.c:249
+#: src/resizecons.c:267
 #, c-format
 msgid "Old #scanlines: %d  New #scanlines: %d  Character height: %d\n"
 msgstr "旧的扫描行个数为: %d 新的扫描行个数为: %d 字符高度为: %d\n"
 
-#: src/resizecons.c:260
+#: src/resizecons.c:278
 #, c-format
 msgid "resizecons: the command `%s' failed\n"
 msgstr "resizecons: 命令 '%s' 失败\n"
 
-#: src/resizecons.c:343
+#: src/resizecons.c:364
 #, c-format
 msgid ""
 "resizecons: don't forget to change TERM (maybe to con%dx%d or linux-%dx%d)\n"
 msgstr "resizecons: 不要忘记修改 TERM (也许修改为 con%dx%d 或 linux-%dx%d)\n"
 
-#: src/resizecons.c:357
+#: src/resizecons.c:378
 #, c-format
 msgid ""
 "resizecons:\n"
@@ -1084,41 +1094,41 @@ msgstr ""
 "或: resizecons -lines ROWS, 其中 ROWS 为 25, 28, 30, 34, 36, 40, 44, 50, 60 "
 "中的一个\n"
 
-#: src/resizecons.c:396
+#: src/resizecons.c:417
 #, c-format
 msgid "resizecons: cannot get I/O permissions.\n"
 msgstr "resizecons: 无法获取 I/O 权限。\n"
 
-#: src/screendump.c:52
+#: src/screendump.c:51
 #, c-format
 msgid "usage: screendump [n]\n"
 msgstr "用法: screendump [n]\n"
 
-#: src/screendump.c:82
+#: src/screendump.c:81
 #, c-format
 msgid "Error reading %s"
 msgstr "读取 %s 出错"
 
-#: src/screendump.c:127
+#: src/screendump.c:126
 #, c-format
 msgid "couldn't read %s, and cannot ioctl dump\n"
 msgstr "无法读取 %s, 并且不能 ioctl 转储\n"
 
-#: src/screendump.c:133
+#: src/screendump.c:132
 #, c-format
 msgid "couldn't read %s\n"
 msgstr "无法读取 %s\n"
 
-#: src/screendump.c:142
+#: src/screendump.c:141
 #, c-format
 msgid "Strange ... screen is both %dx%d and %dx%d ??\n"
 msgstr "奇怪...屏幕既是 %dx%d 又是 %dx%d ？？\n"
 
-#: src/screendump.c:159
+#: src/screendump.c:158
 msgid "Error writing screendump\n"
 msgstr "写入屏幕转储出错\n"
 
-#: src/setfont.c:78
+#: src/setfont.c:77
 #, c-format
 msgid ""
 "Usage: setfont [write-options] [-<N>] [newfont..] [-m consolemap] [-u "
@@ -1171,134 +1181,134 @@ msgstr ""
 "    -V         打印版本并退出。\n"
 "从当前目录或 %s/*/ 加载文件。\n"
 
-#: src/setfont.c:181
+#: src/setfont.c:180
 #, c-format
 msgid "setfont: too many input files\n"
 msgstr "setfont: 太多的输入文件\n"
 
-#: src/setfont.c:189
+#: src/setfont.c:188
 #, c-format
 msgid ""
 "setfont: cannot both restore from character ROM and from file. Font "
 "unchanged.\n"
 msgstr "setfont: 无法既从字符 ROM 进行恢复又从文件进行恢复。字体不变。\n"
 
-#: src/setfont.c:264
+#: src/setfont.c:263
 #, c-format
 msgid "Bad character height %d\n"
 msgstr "错误的字符高度 %d\n"
 
-#: src/setfont.c:268
+#: src/setfont.c:267
 #, c-format
 msgid "Bad character width %d\n"
 msgstr "错误的字符宽度 %d\n"
 
-#: src/setfont.c:293
+#: src/setfont.c:292
 #, c-format
 msgid "%s: font position 32 is nonblank\n"
 msgstr "%s: 字体位置 32 不是空白\n"
 
-#: src/setfont.c:301
+#: src/setfont.c:300
 #, c-format
 msgid "%s: wiped it\n"
 msgstr "%s: 已清除\n"
 
-#: src/setfont.c:305
+#: src/setfont.c:304
 #, c-format
 msgid "%s: background will look funny\n"
 msgstr "%s: 背景将会看起来很有趣\n"
 
-#: src/setfont.c:315
+#: src/setfont.c:314
 #, c-format
 msgid "Loading %d-char %dx%d font from file %s\n"
 msgstr "正在从文件 %4$s 加载 %1$d-字节 %2$dx%3$d 字体\n"
 
-#: src/setfont.c:318
+#: src/setfont.c:317
 #, c-format
 msgid "Loading %d-char %dx%d font\n"
 msgstr "正在加载 %d-字节 %dx%d 字体\n"
 
-#: src/setfont.c:321
+#: src/setfont.c:320
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font from file %s\n"
 msgstr "正在从文件 %5$s 加载 %1$d-字节 %2$dx%3$d (%4$d) 字体\n"
 
-#: src/setfont.c:324
+#: src/setfont.c:323
 #, c-format
 msgid "Loading %d-char %dx%d (%d) font\n"
 msgstr "正在加载 %d-字节 %dx%d (%d) 字体\n"
 
-#: src/setfont.c:380
+#: src/setfont.c:379
 #, c-format
 msgid "%s: bug in do_loadtable\n"
 msgstr "%s: do_loadtable 中的程序错误\n"
 
-#: src/setfont.c:386
+#: src/setfont.c:385
 #, c-format
 msgid "Loading Unicode mapping table...\n"
 msgstr "正在加载 Unicode 映射表 ...\n"
 
-#: src/setfont.c:422 src/setfont.c:510
+#: src/setfont.c:429 src/setfont.c:531
 #, c-format
 msgid "Cannot open font file %s\n"
 msgstr "无法打开字体文件 %s\n"
 
-#: src/setfont.c:433
+#: src/setfont.c:440
 #, c-format
 msgid "When loading several fonts, all must be psf fonts - %s isn't\n"
 msgstr "当加载多个字体时，它们必须都是 psf 字体 - %s 不是\n"
 
-#: src/setfont.c:443
+#: src/setfont.c:455
 #, c-format
 msgid "Read %d-char %dx%d font from file %s\n"
 msgstr "从文件 %4$s 读取 %1$d-字节 %2$dx%3$d 字体\n"
 
-#: src/setfont.c:449
+#: src/setfont.c:461
 #, c-format
 msgid "When loading several fonts, all must have the same height\n"
 msgstr "当加载多个字体时，它们必须具有相同的高度\n"
 
-#: src/setfont.c:456
+#: src/setfont.c:468
 #, c-format
 msgid "When loading several fonts, all must have the same width\n"
 msgstr "当加载多个字体时，它们必须具有相同的宽度\n"
 
-#: src/setfont.c:497
+#: src/setfont.c:518
 #, c-format
 msgid "Cannot find default font\n"
 msgstr "无法找到默认字体\n"
 
-#: src/setfont.c:504
+#: src/setfont.c:525
 #, c-format
 msgid "Cannot find %s font\n"
 msgstr "无法找到 %s 字体\n"
 
-#: src/setfont.c:516
+#: src/setfont.c:537
 #, c-format
 msgid "Reading font file %s\n"
 msgstr "正在读取字体文件 %s\n"
 
-#: src/setfont.c:557
+#: src/setfont.c:581
 #, c-format
 msgid "No final newline in combine file\n"
 msgstr "合并文件结尾处没有新的行\n"
 
-#: src/setfont.c:563
+#: src/setfont.c:587
 #, c-format
 msgid "Too many files to combine\n"
 msgstr "太多的文件需要合并\n"
 
-#: src/setfont.c:587
+#: src/setfont.c:611
 #, c-format
 msgid "Hmm - a font from restorefont? Using the first half.\n"
 msgstr "嗯 - 一个来自 restorefont 的字体？使用它的前一半。\n"
 
-#: src/setfont.c:604
+#: src/setfont.c:628
 #, c-format
 msgid "Bad input file size\n"
 msgstr "错误的输入文件大小\n"
 
-#: src/setfont.c:626
+#: src/setfont.c:650
 #, c-format
 msgid ""
 "This file contains 3 fonts: 8x8, 8x14 and 8x16. Please indicate\n"
@@ -1307,22 +1317,22 @@ msgstr ""
 "这个文件包含3种字体: 8x8, 8x14 和 8x16. 请使用\n"
 "选项 -8 或 -14 或 -16 来指定你想加载哪一个。\n"
 
-#: src/setfont.c:643
+#: src/setfont.c:667
 #, c-format
 msgid "You asked for font size %d, but only 8, 14, 16 are possible here.\n"
 msgstr "你想要字体大小 %d, 但是这里只有 8, 14, 16 可选。\n"
 
-#: src/setfont.c:689
+#: src/setfont.c:713
 #, c-format
 msgid "Found nothing to save\n"
 msgstr "没有找到需要保存的东西\n"
 
-#: src/setfont.c:698
+#: src/setfont.c:722
 #, c-format
 msgid "Saved %d-char %dx%d font file on %s\n"
 msgstr "%d-字节 %dx%d 字体文件已保存到 %s\n"
 
-#: src/setkeycodes.c:26
+#: src/setkeycodes.c:25
 #, c-format
 msgid ""
 "usage: setkeycode scancode keycode ...\n"
@@ -1333,19 +1343,19 @@ msgstr ""
 "(其中扫描码为 xx 或 e0xx, 以十六进制形式给出，\n"
 "键码以十进制形式给出)\n"
 
-#: src/setkeycodes.c:48
+#: src/setkeycodes.c:47
 msgid "even number of arguments expected"
 msgstr "请输入偶数个参数"
 
-#: src/setkeycodes.c:57
+#: src/setkeycodes.c:56
 msgid "error reading scancode"
 msgstr "读取扫描码出错"
 
-#: src/setkeycodes.c:65
+#: src/setkeycodes.c:64
 msgid "code outside bounds"
 msgstr "边界外的键码"
 
-#: src/setkeycodes.c:74
+#: src/setkeycodes.c:73
 #, c-format
 msgid "failed to set scancode %x to keycode %d: ioctl KDSETKEYCODE"
 msgstr "设置扫描码 %x 到键码 %d 失败：ioctl KDSETKEYCODE"
@@ -1516,12 +1526,12 @@ msgstr "旧状态:    "
 msgid "new state:    "
 msgstr "新状态:    "
 
-#: src/setvesablank.c:29
+#: src/setvesablank.c:30
 #, c-format
 msgid "usage: %s\n"
 msgstr "用法: %s\n"
 
-#: src/setvtrgb.c:44
+#: src/setvtrgb.c:43
 #, fuzzy, c-format
 msgid ""
 "Usage: %s [-h] [-V]\n"
@@ -1551,39 +1561,39 @@ msgstr ""
 "然后编辑 <文件> 内的数值。\n"
 "\n"
 
-#: src/setvtrgb.c:75
+#: src/setvtrgb.c:74
 #, c-format
 msgid "Error: %s: Invalid value in field %u in line %u."
 msgstr "错误: %1$s: 行 %3$u 中的字段 %2$u 有无效值。"
 
-#: src/setvtrgb.c:82
+#: src/setvtrgb.c:81
 #, c-format
 msgid "Error: %s: Insufficient number of fields in line %u."
 msgstr "错误: %s: %u 行中字段的数目不足。"
 
-#: src/setvtrgb.c:87
+#: src/setvtrgb.c:86
 #, c-format
 msgid "Error: %s: Line %u has ended unexpectedly.\n"
 msgstr "错误: %s: 行 %u 意外结束。\n"
 
-#: src/setvtrgb.c:91
+#: src/setvtrgb.c:90
 #, c-format
 msgid "Error: %s: Line %u is too long.\n"
 msgstr "错误：%s: 行 %u 太长。\n"
 
-#: src/showconsolefont.c:38
+#: src/showconsolefont.c:37
 msgid "failed to restore original translation table\n"
 msgstr "恢复原始翻译表失败\n"
 
-#: src/showconsolefont.c:42
+#: src/showconsolefont.c:41
 msgid "failed to restore original unimap\n"
 msgstr "恢复原始 unimap 失败\n"
 
-#: src/showconsolefont.c:61
+#: src/showconsolefont.c:60
 msgid "cannot change translation table\n"
 msgstr "无法更改翻译表\n"
 
-#: src/showconsolefont.c:102
+#: src/showconsolefont.c:101
 #, fuzzy, c-format
 msgid ""
 "usage: showconsolefont -V|--version\n"
@@ -1631,16 +1641,16 @@ msgstr ""
 "显示 %d-字节字体\n"
 "\n"
 
-#: src/showkey.c:51
+#: src/showkey.c:49
 msgid "?UNKNOWN?"
 msgstr "?未知的?"
 
-#: src/showkey.c:54
+#: src/showkey.c:52
 #, c-format
 msgid "kb mode was %s\n"
 msgstr "旧的键盘模式是 %s\n"
 
-#: src/showkey.c:56
+#: src/showkey.c:54
 #, c-format
 msgid ""
 "[ if you are trying this under X, it might not work\n"
@@ -1649,12 +1659,12 @@ msgstr ""
 "[ 如果你在 X 中尝试，它可能不会工作\n"
 "因为 X 服务器也在读取 /dev/console ]\n"
 
-#: src/showkey.c:76
+#: src/showkey.c:74
 #, c-format
 msgid "caught signal %d, cleaning up...\n"
 msgstr "捕获到信号 %d，正在清理...\n"
 
-#: src/showkey.c:92
+#: src/showkey.c:90
 #, fuzzy, c-format
 msgid ""
 "showkey version %s\n"
@@ -1709,11 +1719,11 @@ msgstr "按下"
 msgid "keycode %3d %s\n"
 msgstr "键码 %3d %s\n"
 
-#: src/totextmode.c:33
+#: src/totextmode.c:31
 msgid "usage: totextmode\n"
 msgstr "用法：totextmode\n"
 
-#: src/vlock/auth.c:75
+#: src/vlock/auth.c:76
 msgid ""
 "Please try again later.\n"
 "\n"
@@ -1723,17 +1733,17 @@ msgstr ""
 "\n"
 "\n"
 
-#: src/vlock/auth.c:83
+#: src/vlock/auth.c:84
 #, c-format
 msgid "The entire console display is now completely locked by %s.\n"
 msgstr "整个控制台显示器已被 %s 锁定。\n"
 
-#: src/vlock/auth.c:86
+#: src/vlock/auth.c:87
 #, c-format
 msgid "The %s is now locked by %s.\n"
 msgstr "此 %s 现已被 %s 锁定。\n"
 
-#: src/vlock/auth.c:89
+#: src/vlock/auth.c:90
 msgid "Use Alt-function keys to switch to other virtual consoles."
 msgstr "使用 Alt-功能键 (F1..F12) 切换到其他虚拟控制台。"
 
@@ -1742,7 +1752,7 @@ msgstr "使用 Alt-功能键 (F1..F12) 切换到其他虚拟控制台。"
 msgid "Try `%s --help' for more information.\n"
 msgstr "尝试“%s --help”以获得更多信息。\n"
 
-#: src/vlock/parse.c:59
+#: src/vlock/parse.c:60
 #, c-format
 msgid ""
 "%s: locks virtual consoles, saving your current session.\n"
@@ -1766,16 +1776,16 @@ msgstr ""
 msgid "unrecognized user"
 msgstr "无法识别的用户"
 
-#: src/vlock/vlock.c:59
+#: src/vlock/vlock.c:58
 msgid "stdin is not a tty"
 msgstr "stdin 不是 tty"
 
-#: src/vlock/vt.c:148
+#: src/vlock/vt.c:147
 #, c-format
 msgid "This tty (%s) is not a virtual console.\n"
 msgstr "这个 tty (%s) 不是一个虚拟控制台。\n"
 
-#: src/vlock/vt.c:155
+#: src/vlock/vt.c:154
 #, c-format
 msgid "The entire console display cannot be locked.\n"
 msgstr "无法锁定整个控制台显示器。\n"


### PR DESCRIPTION
After some changes in texts needs to be translated or at least before make new release and call to all translators to update *po files "make -C po update-p" should be executed and  all changes generated by this command should be committed.
This PR pushes all this kind of the changes and convert as well po/{da,id,ro}.po files to UTF-8.
