### PR TITLE
configure.ac: Fix logic of vlock configure switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ AM_CONDITIONAL(BUILD_LIBKEYMAP, test "$BUILD_LIBKEYMAP" = "yes")
 
 AC_ARG_ENABLE(vlock,
 	AS_HELP_STRING(--disable-vlock, [do not build vlock]),
-	[VLOCK_PROG=no],[VLOCK_PROG=yes])
+	[VLOCK_PROG=$enableval],[VLOCK_PROG=yes])
 AM_CONDITIONAL(VLOCK, test "$VLOCK_PROG" = "yes")
 
 if test "$VLOCK_PROG" = "yes"; then


### PR DESCRIPTION
Downstream bug report: https://bugs.gentoo.org/661650

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>