### PR TITLE
Add Apple USB keyboard models A1048 and A1243, Swedish localization

### DIFF
--- a/data/keymaps/mac/all/apple-a1048-sv.map
+++ b/data/keymaps/mac/all/apple-a1048-sv.map
@@ -1,0 +1,70 @@
+# Apple USB keyboard model A1048 with keypad, plastic enclosure
+#
+# This mapping is designed to correspond to standard Apple keys.
+#
+# idVendor     0x05ac Apple, Inc.
+# idProduct    0x020c Extended Keyboard
+# bCountryCode     13 International (ISO) Swedish localization
+
+strings as usual
+
+include "apple-a1048-base"
+
+keymaps 0,1,4,8,9 # Plain Shift Control Alt Shift+Alt
+
+keycode   2 = one   exclam     VoidSymbol           copyright    exclamdown
+keycode   3 = two   quotedbl   VoidSymbol           at           U+201D
+keycode   4 = three numbersign VoidSymbol           sterling     yen
+keycode   5 = four  euro       Control_backslash    dollar       cent
+keycode   6 = five  percent    Control_bracketright U+221E       permille
+keycode   7 = six   ampersand  Control_asciicircum  section      paragraph
+keycode   8 = seven slash      Control_underscore   bar          backslash
+keycode   9 = eight parenleft  VoidSymbol           bracketleft  braceleft
+keycode  10 = nine  parenright VoidSymbol           bracketright braceright
+keycode  11 = zero  equal      VoidSymbol           U+2248       U+2260
+keycode  12 = plus  question   Control_underscore   plusminus    questiondown
+
+keycode  13 = dead_acute dead_grave VoidSymbol acute grave
+
+keycode  16 = +q +Q Control_q  bullet      degree
+keycode  17 = +w +W Control_w  U+03A9      U+02DD
+keycode  18 = +e +E Control_e +eacute     +Eacute
+keycode  19 = +r +R Control_r  registered  U+221A
+keycode  20 = +t +T Control_t  U+2020      U+2021
+keycode  21 = +y +Y Control_y  mu          U+02DC
+keycode  22 = +u +U Control_u +udiaeresis +Udiaeresis
+keycode  23 = +i +I Control_i  U+0131      U+02C6
+keycode  24 = +o +O Control_o +U+0153     +U+0152
+keycode  25 = +p +P Control_p +U+03C0     +U+220F
+
+keycode  26 = +aring          +Aring           VoidSymbol U+02D9     U+02DA
+keycode  27 =  dead_diaeresis  dead_circumflex VoidSymbol dead_tilde circumflex
+
+keycode  30 = +a +A Control_a VoidSymbol  U+25CA
+keycode  31 = +s +S Control_s ssharp      U+2211
+keycode  32 = +d +D Control_d U+2202      U+2206
+keycode  33 = +f +F Control_f U+0192      U+222B
+keycode  34 = +g +G Control_g cedilla     macron
+keycode  35 = +h +H Control_h U+02DB      U+02D8
+keycode  36 = +j +J Control_j U+221A      notsign
+keycode  37 = +k +K Control_k ordfeminine masculine
+keycode  38 = +l +L Control_l # FIXME: U+FB01      U+FB02
+
+keycode  39 = +odiaeresis +Odiaeresis VoidSymbol +oslash +Oslash
+keycode  40 = +adiaeresis +Adiaeresis VoidSymbol +ae     +AE
+keycode  86 = less         greater    VoidSymbol  U+2264  U+2265
+keycode  43 = apostrophe   asterisk   VoidSymbol  U+2122  U+2019
+
+keycode  44 = +z +Z Control_z  division  U+2044
+keycode  45 = +x +X Control_x  U+2248    U+02C7
+keycode  46 = +c +C Control_c +ccedilla +Ccedilla
+keycode  47 = +v +V Control_v  U+2039    guillemotleft
+keycode  48 = +b +B Control_b  U+203A    guillemotright
+keycode  49 = +n +N Control_n  U+2018    U+201C
+keycode  50 = +m +M Control_m  U+2019    U+201D
+
+keycode  51 = comma  semicolon  VoidSymbol U+201A U+201E
+keycode  52 = period colon      VoidSymbol U+2026 periodcentered
+keycode  53 = minus  underscore VoidSymbol U+2013 U+2014
+
+keycode  41 = section degree VoidSymbol paragraph bullet

--- a/data/keymaps/mac/all/apple-a1243-sv-fn-reverse.map
+++ b/data/keymaps/mac/all/apple-a1243-sv-fn-reverse.map
@@ -1,0 +1,13 @@
+# Apple USB keyboard model A1243 with keypad, aluminium enclosure
+#
+# The mapping is designed to correspond to standard Apple keys,
+# including the behaviour of the shift and the alternate keys. The
+# behaviour of the Fn key is reversed for the feature and function
+# keys. Use "apple-a1243-sv.map" for default behaviour.
+#
+# idVendor     0x05ac Apple, Inc.
+# idProduct    0x0221 Aluminum Keyboard (ISO)
+# bCountryCode     13 International (ISO) Swedish localization
+
+include "apple-a1243-sv.map"
+include "apple-a1243-fn-reverse"

--- a/data/keymaps/mac/all/apple-a1243-sv.map
+++ b/data/keymaps/mac/all/apple-a1243-sv.map
@@ -1,7 +1,9 @@
 # Apple USB keyboard model A1243 with keypad, aluminium enclosure
 #
 # The mapping is designed to correspond to standard Apple keys,
-# including the behaviour of the shift and the alternate keys.
+# including the behaviour of the shift and the alternate keys. Use
+# "apple-a1243-sv-fn-reverse.map" to reverse the default behaviour
+# of the Fn key for feature and function keys.
 #
 # idVendor     0x05ac Apple, Inc.
 # idProduct    0x0221 Aluminum Keyboard (ISO)

--- a/data/keymaps/mac/all/apple-a1243-sv.map
+++ b/data/keymaps/mac/all/apple-a1243-sv.map
@@ -1,0 +1,15 @@
+# Apple USB keyboard model A1243 with keypad, aluminium enclosure
+#
+# The mapping is designed to correspond to standard Apple keys,
+# including the behaviour of the shift and the alternate keys.
+#
+# idVendor     0x05ac Apple, Inc.
+# idProduct    0x0221 Aluminum Keyboard (ISO)
+# bCountryCode     13 International (ISO) Swedish localization
+
+include "apple-a1048-sv.map"
+include "apple-a1243-fn"
+
+keycode 41 = less    greater VoidSymbol U+2264    U+2265
+keycode 86 = section degree  VoidSymbol paragraph bullet
+keycode 83 = comma # Keypad comma

--- a/data/keymaps/mac/all/apple-internal-0x0253-sv-fn-reverse.map
+++ b/data/keymaps/mac/all/apple-internal-0x0253-sv-fn-reverse.map
@@ -3,13 +3,13 @@
 # This keyboard is present in for example the MacBook 2011.
 #
 # The mapping is designed to correspond to standard Apple keys,
-# including the behaviour of the shift and the alternate keys. Use
-# "apple-internal-0x0253-sv-fn-reverse.map" to reverse the default
-# behaviour of the Fn key for feature and function keys.
+# including the behaviour of the shift and the alternate keys. The
+# behaviour of the Fn key is reversed for the feature and function
+# keys. Use "apple-internal-0x0253-sv.map" for default behaviour.
 #
 # idVendor     0x05ac Apple, Inc.
 # idProduct    0x0253 Internal Keyboard/Trackpad (ISO)
 # bCountryCode     13 International (ISO) Swedish localization
 
 include "apple-a1048-sv.map"
-include "apple-a1243-fn"
+include "apple-a1243-fn-reverse"

--- a/data/keymaps/mac/all/apple-internal-0x0253-sv.map
+++ b/data/keymaps/mac/all/apple-internal-0x0253-sv.map
@@ -1,0 +1,13 @@
+# Apple USB internal keyboard/trackpad (ISO)
+#
+# This keyboard is present in for example the MacBook 2011.
+#
+# The mapping is designed to correspond to standard Apple keys,
+# including the behaviour of the shift and the alternate keys.
+#
+# idVendor     0x05ac Apple, Inc.
+# idProduct    0x0253 Internal Keyboard/Trackpad (ISO)
+# bCountryCode     13 International (ISO) Swedish localization
+
+include "apple-a1048-sv.map"
+include "apple-a1243-fn"

--- a/data/keymaps/mac/include/apple-a1048-base.inc
+++ b/data/keymaps/mac/include/apple-a1048-base.inc
@@ -1,0 +1,85 @@
+# Apple USB keyboard model A1048 with keypad, plastic enclosure
+#
+# idVendor     0x05ac Apple, Inc.
+# idProduct    0x020c Extended Keyboard
+#
+# Base map without localization specific keys.
+
+keymaps 0,1,4,8,9 # Plain Shift Control Alt Shift+Alt
+
+keycode   1 = Escape
+keycode  14 = Delete Delete Delete Delete       Delete
+keycode  15 = Tab    Tab    Tab    Tab          Tab
+keycode  28 = Return Return Return Return       Return
+keycode  57 = space  space  space  nobreakspace nobreakspace
+
+# Modifier keys
+# Note: Apple keyboards normally do not distinguish
+# between left and right modifiers keys.
+keycode  29 = Control    # Left Control
+keycode  97 = Control    # Right Control
+keycode  42 = Shift      # Left Shift
+keycode  54 = Shift      # Right Shift
+keycode  56 = Alt        # Left Alt
+keycode 100 = Alt        # Right Alt
+keycode 125 = VoidSymbol # Left Command
+keycode 126 = VoidSymbol # Right Command
+keycode  58 = Caps_Lock
+
+# Keypad keys
+keycode  69 = U+2327 # Clear
+keycode 117 = equal
+keycode  98 = slash
+keycode  55 = asterisk
+keycode  74 = minus
+keycode  78 = plus
+keycode  94 = Return
+
+keycode  82 = zero
+keycode  79 = one
+keycode  80 = two
+keycode  81 = three
+keycode  75 = four
+keycode  76 = five
+keycode  77 = six
+keycode  71 = seven
+keycode  72 = eight
+keycode  73 = nine
+keycode  83 = period
+
+# Edit keys
+keycode 110 = Help
+keycode 111 = Remove
+keycode 102 = Home
+keycode 107 = End
+keycode 104 = PageUp
+keycode 109 = PageDown
+
+keycode 105 = Left
+keycode 103 = Up
+keycode 108 = Down
+keycode 106 = Right
+
+# Function keys, both Alt+F<n> and Control+Alt+F<n> switch to Console_<n>
+keycode  59 = F1  F1  VoidSymbol Console_1  Console_1
+keycode  60 = F2  F2  VoidSymbol Console_2  Console_2
+keycode  61 = F3  F3  VoidSymbol Console_3  Console_3
+keycode  62 = F4  F4  VoidSymbol Console_4  Console_4
+keycode  63 = F5  F5  VoidSymbol Console_5  Console_5
+keycode  64 = F6  F6  VoidSymbol Console_6  Console_6
+keycode  65 = F7  F7  VoidSymbol Console_7  Console_7
+keycode  66 = F8  F8  VoidSymbol Console_8  Console_8
+keycode  67 = F9  F9  VoidSymbol Console_9  Console_9
+keycode  68 = F10 F10 VoidSymbol Console_10 Console_10
+keycode  87 = F11 F11 VoidSymbol Console_11 Console_11
+keycode  88 = F12 F12 VoidSymbol Console_12 Console_12
+keycode 183 = F13 F13 VoidSymbol Console_13 Console_13
+keycode 184 = F14 F14 VoidSymbol Console_14 Console_14
+keycode 185 = F15 F15 VoidSymbol Console_15 Console_15
+keycode 186 = F16 F16 VoidSymbol Console_16 Console_16
+
+# Feature keys
+keycode 113 = VoidSymbol # Mute
+keycode 114 = VoidSymbol # Volume Down
+keycode 115 = VoidSymbol # Volume Up
+keycode 161 = VoidSymbol # Eject

--- a/data/keymaps/mac/include/apple-a1243-fn-reverse.inc
+++ b/data/keymaps/mac/include/apple-a1243-fn-reverse.inc
@@ -1,0 +1,51 @@
+# Apple USB keyboard model A1243 with keypad, aluminium enclosure
+#
+# Map feature and function keys to correspond to reversed Apple keys.
+#
+# idVendor     0x05ac Apple, Inc.
+# idProduct    0x0221 Aluminum Keyboard (ISO)
+#
+# The top row keys can be used as function keys (F1-F19). They can also be
+# used to control features such as volume adjustments by holding the Fn key.
+# This behaviour is reversed in key map "apple-a1243-fn.inc", which is
+# Apple default.
+
+keymaps 0,1,4,8,12       # Plain Shift Control Alt Control+Alt
+
+keycode 464 = VoidSymbol # Function key
+
+# Both Alt+F<n> and Control+Alt+F<n> switch to Console_<n>.
+keycode 224 = F1  F1  VoidSymbol Console_1  Console_1
+keycode 225 = F2  F2  VoidSymbol Console_2  Console_2
+keycode 120 = F3  F3  VoidSymbol Console_3  Console_3
+keycode 204 = F4  F4  VoidSymbol Console_4  Console_4
+keycode 229 = F5  F5  VoidSymbol Console_5  Console_5
+keycode 230 = F6  F6  VoidSymbol Console_6  Console_6
+keycode 165 = F7  F7  VoidSymbol Console_7  Console_7
+keycode 164 = F8  F8  VoidSymbol Console_8  Console_8
+keycode 163 = F9  F9  VoidSymbol Console_9  Console_9
+keycode 113 = F10 F10 VoidSymbol Console_10 Console_10
+keycode 114 = F11 F11 VoidSymbol Console_11 Console_11
+keycode 115 = F12 F12 VoidSymbol Console_12 Console_12
+keycode 183 = F13 F13 VoidSymbol Console_13 Console_13
+keycode 184 = F14 F14 VoidSymbol Console_14 Console_14
+keycode 185 = F15 F15 VoidSymbol Console_15 Console_15
+keycode 186 = F16 F16 VoidSymbol Console_16 Console_16
+keycode 187 = F17 F17 VoidSymbol Console_17 Console_17
+keycode 188 = F18 F18 VoidSymbol Console_18 Console_18
+keycode 189 = F19 F19 VoidSymbol Console_19 Console_19
+
+# Feature keys
+keycode  59 = VoidSymbol # Brightness Down
+keycode  60 = VoidSymbol # Brightness Up
+keycode  61 = VoidSymbol # Exposé / Mission Control
+keycode  62 = VoidSymbol # Dashboard / Launchpad
+keycode  63 = VoidSymbol # Unused
+keycode  64 = VoidSymbol # Unused
+keycode  65 = VoidSymbol # Rewind (Previous Track)
+keycode  66 = VoidSymbol # Play / Pause
+keycode  67 = VoidSymbol # Fast Forward (Next Track)
+keycode  68 = VoidSymbol # Mute
+keycode  87 = VoidSymbol # Volume Down
+keycode  88 = VoidSymbol # Volume Up
+keycode 161 = VoidSymbol # Eject

--- a/data/keymaps/mac/include/apple-a1243-fn.inc
+++ b/data/keymaps/mac/include/apple-a1243-fn.inc
@@ -1,0 +1,52 @@
+# Apple USB keyboard model A1243 with keypad, aluminium enclosure
+#
+# Map feature and function keys to correspond to standard Apple keys.
+#
+# idVendor     0x05ac Apple, Inc.
+# idProduct    0x0221 Aluminum Keyboard (ISO)
+#
+# The top row keys can be used to control features such as volume
+# adjustments. They can also be used as function keys (F1-F19) by holding
+# the Fn key. Apple default is to perform the feature indicated by the
+# icon printed on the key. This behaviour is reversed in key map
+# "apple-a1243-fn-reverse.inc".
+
+keymaps 0,1,4,8,12       # Plain Shift Control Alt Control+Alt
+
+keycode 464 = VoidSymbol # Function key
+
+# Both Fn+Alt+F<n> and Fn+Control+Alt+F<n> switch to Console_<n>.
+keycode  59 = F1  F1  VoidSymbol Console_1  Console_1
+keycode  60 = F2  F2  VoidSymbol Console_2  Console_2
+keycode  61 = F3  F3  VoidSymbol Console_3  Console_3
+keycode  62 = F4  F4  VoidSymbol Console_4  Console_4
+keycode  63 = F5  F5  VoidSymbol Console_5  Console_5
+keycode  64 = F6  F6  VoidSymbol Console_6  Console_6
+keycode  65 = F7  F7  VoidSymbol Console_7  Console_7
+keycode  66 = F8  F8  VoidSymbol Console_8  Console_8
+keycode  67 = F9  F9  VoidSymbol Console_9  Console_9
+keycode  68 = F10 F10 VoidSymbol Console_10 Console_10
+keycode  87 = F11 F11 VoidSymbol Console_11 Console_11
+keycode  88 = F12 F12 VoidSymbol Console_12 Console_12
+keycode 183 = F13 F13 VoidSymbol Console_13 Console_13
+keycode 184 = F14 F14 VoidSymbol Console_14 Console_14
+keycode 185 = F15 F15 VoidSymbol Console_15 Console_15
+keycode 186 = F16 F16 VoidSymbol Console_16 Console_16
+keycode 187 = F17 F17 VoidSymbol Console_17 Console_17
+keycode 188 = F18 F18 VoidSymbol Console_18 Console_18
+keycode 189 = F19 F19 VoidSymbol Console_19 Console_19
+
+# Feature keys
+keycode 224 = VoidSymbol # Brightness Down
+keycode 225 = VoidSymbol # Brightness Up
+keycode 120 = VoidSymbol # Exposé / Mission Control
+keycode 204 = VoidSymbol # Dashboard / Launchpad
+keycode 229 = VoidSymbol # Unused
+keycode 230 = VoidSymbol # Unused
+keycode 165 = VoidSymbol # Rewind (Previous Track)
+keycode 164 = VoidSymbol # Play / Pause
+keycode 163 = VoidSymbol # Fast Forward (Next Track)
+keycode 113 = VoidSymbol # Mute
+keycode 114 = VoidSymbol # Volume Down
+keycode 115 = VoidSymbol # Volume Up
+keycode 161 = VoidSymbol # Eject


### PR DESCRIPTION
Hi,

This patch series adds keymaps for Apple USB keyboard models A1048 and
A1243, localized for Swedish. The internal USB keyboard mapping for the
MacBook 2011 is also added.

The mappings are designed to correspond to standard Apple keys, including
the behaviour of the shift and the alternate keys.

The top row keys with printed feature icons are normally used to control
features such as volume adjustments in macOS. They can also be used as
function keys (F1-F19) by holding the Fn key. The default behaviour of
the Fn key can be reversed.

The presence of these keyboards can probably be detected reliably by
their USB identification numbers and country code, annotated in the map
file notes. An autodetection implementation would be very helpful for
users.

For some reason, mapping U+FB01 for LATIN SMALL LIGATURE FI and U+FB02
for LATIN SMALL LIGATURE FL yield the error

	unicode keysym out of range: U+FB01
	syntax error, unexpected ERROR, expecting EOL
	unicode keysym out of range: U+FB02
	syntax error, unexpected ERROR, expecting EOL

from loadkeys(1). These are marked as FIXME in the map file.