### PR TITLE
vlock: allow sudo user to unlock his session

### DIFF
--- a/src/vlock/username.c
+++ b/src/vlock/username.c
@@ -40,17 +40,18 @@ get_username(void)
 {
 	const char *name;
 	struct passwd *pw = 0;
+	char *logname = NULL;
 	uid_t uid         = getuid();
 
-	char *logname = getenv("LOGNAME");
+	/* If a non-root runs a sudo session, ask for user's
+	 * password to unlock it, not root's password */
+	logname = getenv("SUDO_USER");
+	if (logname == NULL)
+		logname = getenv("LOGNAME");
 
-	if (logname) {
-		pw = getpwnam(logname);
-		/* Ensure uid is same as current. */
-		if (pw && pw->pw_uid != uid)
-			pw = 0;
-	}
-	if (!pw)
+	pw = getpwnam(logname);
+
+	if (!pw && uid)
 		pw = getpwuid(uid);
 
 	if (!pw)


### PR DESCRIPTION

If a non-root user ran sth like "sudo -i" and vlock'ed from inside it,
then that user himself should be able to unlock his console.

```
[user@HP-Elite-7300 tmp]$ echo $LOGNAME
user
[user@HP-Elite-7300 tmp]$ sudo -i
root@HP-Elite-7300:~# echo $LOGNAME
root
root@HP-Elite-7300:~# echo $SUDO_USER
user
root@HP-Elite-7300:~#
```

Tested on `rosa2019.1` + kbd 2.2.0 + this patch:

```
[root@rosa-2019 kbd]# su - user
[user@rosa-2019 ~]$ sudo -i
[sudo] password for user:
[root@rosa-2019 ~]# vlock
Данное устройство tty (console) не является виртуальной консолью.
Блокировка console установлена user.
Пароль:
[root@rosa-2019 ~]#
```
sudo root session was successfully unlocked with user's password.
```
[root@rosa-2019 ~]# unset SUDO_USER
[root@rosa-2019 ~]# vlock
Данное устройство tty (console) не является виртуальной консолью.
Блокировка console установлена root.
Пароль:
```
root password is requested without $SUDO_ENV.

Another vlock implementation [1, 2] does not check that UIDs match,
I do not see sense in this check, removing it to make what I want work.

[1] Another vlock implementation: https://github.com/WorMzy/vlock
[2] My similar patch for it: https://github.com/mikhailnov/vlock/commit/ba38d5d563cdfaad3b2f260248b3434c235a7afd