### PR TITLE
PAM config added to destination

### DIFF
--- a/src/vlock/Makefile.am
+++ b/src/vlock/Makefile.am
@@ -3,10 +3,15 @@ AM_CPPFLAGS = \
 	-I$(srcdir)/../libcommon -I$(builddir)/../libcommon \
 	-D_GNU_SOURCE -DLOCALEDIR=\"$(localedir)\"
 
-EXTRA_DIST = README.vlock
+EXTRA_DIST = README.vlock vlock.pamd
 
 if VLOCK
 bin_PROGRAMS = vlock
+
+install-data-local:
+	install -Dm644 $(srcdir)/vlock.pamd $(DESTDIR)$(sysconfdir)/pam.d/vlock
+uninstall-local:
+	rm $(DESTDIR)$(sysconfdir)/pam.d/vlock
 endif
 
 vlock_SOURCES  = \


### PR DESCRIPTION
Now when installing, vlock.pamd will be copied to /etc/pam.d/vlock