### PR TITLE
Add braces to IT keyboard map

### DIFF
--- a/data/keymaps/i386/qwerty/it.map
+++ b/data/keymaps/i386/qwerty/it.map
@@ -12,6 +12,10 @@
 #
 # Emanuele Tomasi <targzeta@gmail.com>
 
+# Added '{' and '}', obtained respectively by Shift-[ and Shift-].
+#
+# Tommaso Bonvicini <tommasobonvicini@gmail.com>
+
 keymaps 0-3,4-6,8-10,12-14
 include "qwerty-layout"
 include "linux-keys-bare"
@@ -158,3 +162,6 @@ shift control alt keycode  53 = Meta_Control_underscore
 shift control alt keycode  13 = Meta_Control_asciicircum
 
 altgr control alt keycode  27 = Meta_Control_bracketright
+
+shift altgr keycode  26 = braceleft
+shift altgr keycode  27 = braceright


### PR DESCRIPTION
This PR is related to #51.
This is a fix I implemented back in time to fix braces on my Surface Pro 4 italian keyboard.
I'm not sure if this is the right way to handle the problem, since I simply added new key mappings without checking pre-existing ones nor studying the entire `it.map` file.
This patch made the keyboard usable for me for my programming use case.

I would ask the issuer GFdevelop to give this patch a try on all the mentioned machines.