### PR TITLE
Add hexadecimal file support for setvtrgb.

### DIFF
--- a/contrib/vtrgb-dec2hex.sh
+++ b/contrib/vtrgb-dec2hex.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+# convert setvtrgb decimal file to hexadecimal
+
+if [[ -z "$1" ]]; then
+	echo "usage: vtrgb-dec2hex.sh <decfile_path>"
+	exit
+fi
+
+declare -i x=0
+declare -i y=0
+declare -A d
+
+mapfile decimals < $1
+
+for line in ${decimals[@]}; do
+	x=0
+	IFS=,
+	for dec in $line; do
+		d[$y,$x]=$dec
+		x+=1
+	done
+	y+=1
+done
+
+for x in {0..15}; do
+	printf "#%02x%02x%02x\n" ${d[0,$x]} ${d[1,$x]} ${d[2,$x]}
+done

--- a/contrib/vtrgb.ubuntu.hex
+++ b/contrib/vtrgb.ubuntu.hex
@@ -1,0 +1,16 @@
+#010101
+#de382b
+#39b54a
+#ffc706
+#006fb8
+#762671
+#2cb5e9
+#cccccc
+#808080
+#ff0000
+#00ff00
+#ffff00
+#0000ff
+#ff00ff
+#00ffff
+#ffffff

--- a/docs/man/man8/setvtrgb.8
+++ b/docs/man/man8/setvtrgb.8
@@ -11,14 +11,15 @@ The
 .I setvtrgb
 command takes a single argument, either the string
 .B vga
-, or a path to a file
-containing the red, green, and blue colors to be used by the Linux virtual terminals.
+, or a path to a file containing the colors to be used by
+the Linux virtual terminals.
 
-If you use the
+You can choose to write the colors in decimal or hexadecimal format,
+it will be detected on runtime.
+
+Decimal
 .B FILE
-parameter,
-.B FILE
-should be exactly 3 lines of 16
+format should be exactly 3 lines of 16
 comma-separated decimal values for RED, GREEN, and BLUE.
 
 To seed a valid
@@ -30,6 +31,31 @@ To seed a valid
 
 And then edit the values in
 .B FILE
+
+Hexadecimal
+.B FILE
+format should be exactly 16 lines of hex triplets for RED, GREEN and BLUE,
+prefixed with a number sign (#). For example:
+.nf
+.RS
+.B #000000
+.B #AA0000
+.B #00AA00
+.B #AA5500
+.B #0000AA
+.B #AA00AA
+.B #00AAAA
+.B #AAAAAA
+.B #555555
+.B #FF5555
+.B #55FF55
+.B #FFFF55
+.B #5555FF
+.B #FF55FF
+.B #55FFFF
+.B #FFFFFF
+.RE
+.fi
 
 .SH OPTIONS
 .TP

--- a/tests/e2e-setvtrgb.at
+++ b/tests/e2e-setvtrgb.at
@@ -11,3 +11,10 @@ AT_SKIP_IF([ test "$TRAVIS_SANDBOX" != "priviliged" ])
 E2E_CHECK(["$abs_top_builddir/src/setvtrgb" -C /dev/tty0 "$abs_top_srcdir/contrib/vtrgb.ubuntu"])
 E2E_COMPARE_SYSCALLS([cat $abs_srcdir/data/e2e/setvtrgb-test02.calls])
 AT_CLEANUP
+
+AT_SETUP([setvtrgbt (vtrgb.ubuntu.hex)])
+AT_KEYWORDS([e2e setvtrgb])
+AT_SKIP_IF([ test "$TRAVIS_SANDBOX" != "priviliged" ])
+E2E_CHECK(["$abs_top_builddir/src/setvtrgb" -C /dev/tty0 "$abs_top_srcdir/contrib/vtrgb.ubuntu.hex"])
+E2E_COMPARE_SYSCALLS([cat $abs_srcdir/data/e2e/setvtrgb-test02.calls])
+AT_CLEANUP


### PR DESCRIPTION
pull request for #60 

hmm, i did this with root user, in tty3:

```
make check CHECK_KEYWORDS="unittest e2e"
```

but "setvtrgbt" tests (where i added my test too) are still skipped...

> cause vagrant/vbox has some issues with tty (i guess just on my machine, when i press enter it's like it keeps pressing enter forever and hogs the host), i tried this on my real machine...

so i don't know if my test works (just adapted from vtrgb.ubuntu test), but running setvtrgb manually with a hex file works.

please let me know if there's anything to fix! (not so sure about the man page and usage message changes...)

ps. i did `clang-format -i -style=file src/setvtrgb.c` but it changed more than my code, so i reverted that... but i think i followed the existing style anyway.