### PR TITLE
Fix incorrect accentuation pt-latin9

### DIFF
--- a/data/keymaps/i386/qwerty/pt-latin9.map
+++ b/data/keymaps/i386/qwerty/pt-latin9.map
@@ -7,6 +7,7 @@ keymaps 0-2,4,6,8,12
 alt_is_meta
 include "qwerty-layout"
 include "linux-with-alt-and-altgr"
+include "compose.latin"
 strings as usual
 
 keycode   1 = Escape


### PR DESCRIPTION
Fix incorrect accentuation pt-latin9, like suggested at issue #64 