### PR TITLE
libkfont: Initialize kfont_context->options

### DIFF
--- a/src/libkfont/context.c
+++ b/src/libkfont/context.c
@@ -143,11 +143,12 @@ kfont_init(const char *prefix, struct kfont_context **ctx)
 {
 	struct kfont_context *p;
 
-	if (!(p = malloc(sizeof(*p))))
+	if (!(p = calloc(1, sizeof(*p))))
 		return -EX_OSERR;
 
 	p->progname = prefix;
 	p->verbose = 0;
+	p->options = 0;
 	p->log_fn = log_stderr;
 	p->mapdirpath = mapdirpath;
 	p->mapsuffixes = mapsuffixes;


### PR DESCRIPTION
kfont_init did not set the options member, so it had essentially random
content. This made setfont behave weirdly.

Switch to calloc for good measure to avoid issues like this.

Signed-off-by: Fabian Vogt <fvogt@suse.de>

Initially found by openQA which randomly saw huge text: https://openqa.opensuse.org/tests/2087792#step/consoletest_setup/52

Can be reproduced reliably with `MALLOC_PERTURB_=69 setfont eurlatgr`.