### PR TITLE
Update la-latin1.map

### DIFF
--- a/data/keymaps/i386/qwerty/la-latin1.map
+++ b/data/keymaps/i386/qwerty/la-latin1.map
@@ -1,15 +1,7 @@
 # From jfernand@dc.uba.ar Mon Apr 21 22:00:42 1997
 ! Latin American keyboard, loosely based on Jon Tombs' and Julio Sanchez's
-! Spanish keyboard. Read the Spahish and Keyboard HOWTOs for information on
+! Spanish keyboard. Read the Spanish and Keyboard HOWTOs for information on
 ! how to configure your system to use the extended symbols.
-!
-! shift keycode 41 is mapped to masculine because I wasn't able to
-! figure out the correct keysym for that character. If you do, please
-! contact me.
-!
-! Please do send any comments/suggestions to the following address:
-!
-! Javier Fernandez Ivern <jfernand@dc.uba.ar>
 !
 keymaps 0-2,4-6,8-10,12-14
 alt_is_meta
@@ -43,11 +35,11 @@ keycode  28 = Return
 	alt	keycode  28 = Meta_Control_m
 keycode  29 = Control
 keycode  39 = ntilde           Ntilde
-keycode  40 = braceleft        bracketleft      asciicircum
+keycode  40 = braceleft        bracketleft      dead_circumflex
 	altgr	control	keycode  40 = Control_asciicircum
-keycode  41 = bar              masculine        notsign
+keycode  41 = bar              degree        notsign
 keycode  42 = Shift
-keycode  43 = braceright       bracketright     grave
+keycode  43 = braceright       bracketright     dead_grave
 	shift	control	keycode  43 = Control_bracketright
 keycode  51 = comma            semicolon
 keycode  52 = period           colon
@@ -66,10 +58,47 @@ compose '\'' 'e' to eacute
 compose '\'' 'i' to iacute
 compose '\'' 'o' to oacute
 compose '\'' 'u' to uacute
+compose '\'' 'y' to yacute
 compose '\'' 'A' to Aacute
 compose '\'' 'E' to Eacute
 compose '\'' 'I' to Iacute
 compose '\'' 'O' to Oacute
 compose '\'' 'U' to Uacute
+compose '\'' 'Y' to Yacute
+
+compose '"' 'a' to adiaeresis
+compose '"' 'e' to ediaeresis
+compose '"' 'i' to idiaeresis
+compose '"' 'o' to odiaeresis
 compose '"' 'u' to udiaeresis
+compose '"' 'y' to ydiaeresis
+compose '"' 'A' to Adiaeresis
+compose '"' 'E' to Ediaeresis
+compose '"' 'I' to Idiaeresis
+compose '"' 'O' to Odiaeresis
 compose '"' 'U' to Udiaeresis
+compose '"' 'Y' to Ydiaeresis
+
+compose '`' 'a' to agrave
+compose '`' 'e' to egrave
+compose '`' 'i' to igrave
+compose '`' 'o' to ograve
+compose '`' 'u' to ugrave
+compose '`' 'A' to Agrave
+compose '`' 'E' to Egrave
+compose '`' 'I' to Igrave
+compose '`' 'O' to Ograve
+compose '`' 'U' to Ugrave
+compose '`' ' ' to grave
+
+compose '^' 'a' to acircumflex
+compose '^' 'e' to ecircumflex
+compose '^' 'i' to icircumflex
+compose '^' 'o' to ocircumflex
+compose '^' 'u' to ucircumflex
+compose '^' 'A' to Acircumflex
+compose '^' 'E' to Ecircumflex
+compose '^' 'I' to Icircumflex
+compose '^' 'O' to Ocircumflex
+compose '^' 'U' to Ucircumflex
+compose '^' ' ' to asciicircum


### PR DESCRIPTION
Corrected the layout, according to the Spanish (Latin America) layout specification.
- The corner alpha now produces the degree sign instead of the ordinal masculine sign.
- Added the missing dead keys for the grave and circumflex accents.
- All four diacritic dead keys take all vowels; the acute accent and the diaeresis also accept the letter Y.

See https://www.farah.cl/Keyboardery/A-Visual-Comparison-of-Different-National-Layouts/#esLA for further reference.

Signed-off-by: Miguel Farah <miguel@farah.cl>