### PR TITLE
Do not look up include files in the current working directory

### DIFF
--- a/src/libkeymap/analyze.l
+++ b/src/libkeymap/analyze.l
@@ -103,7 +103,6 @@ static const char *const include_dirpath0[] = {
 	NULL
 };
 static const char *const include_dirpath1[] = {
-	"",
 	"../include/",
 	"../../include/",
 	NULL


### PR DESCRIPTION
Fixes the same issue as a770f39f79e6a5fdf8f352d8b26d6a50c6b137ff but for include files.

Link: #101
Signed-off-by: Daan De Meyer <daan.j.demeyer@gmail.com>