### PR TITLE
Use HTTPS for GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To summarize, the stable release is `2.1.0` while `2.0.9x` is a pre-releases.
 
 Git repository:
 * Primary: git://git.kernel.org/pub/scm/linux/kernel/git/legion/kbd.git
-* Mirror:  git://github.com/legionus/kbd.git
+* Mirror:  https://github.com/legionus/kbd.git
 
 Git Branches: `git branch -a`
 

--- a/docs/process/howto-contribute.md
+++ b/docs/process/howto-contribute.md
@@ -52,7 +52,7 @@ To summarize, the stable release is `2.1.0` while `2.0.9x` is a pre-releases.
 
 Git repository:
 * Primary: git://git.kernel.org/pub/scm/linux/kernel/git/legion/kbd.git
-* Mirror:  git://github.com/legionus/kbd.git
+* Mirror:  https://github.com/legionus/kbd.git
 
 Git Branches: `git branch -a`
 


### PR DESCRIPTION
GitHub has dropped support for the git:// protocol:
https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/