### PR TITLE
loadkeys: Add `--tkeymap` to dump the keymap as text

### DIFF
--- a/docs/man/man1/loadkeys.1.gen
+++ b/docs/man/man1/loadkeys.1.gen
@@ -16,6 +16,9 @@ loadkeys \- load keyboard translation tables
 .I --bkeymap
 .br
 .B loadkeys
+.IB --tkeymap "[=shape]"
+.br
+.B loadkeys
 .I --parse
 .LP
 .SH DESCRIPTION
@@ -134,6 +137,45 @@ prints to the standard output a file that may be used as a binary
 keymap as expected by Busybox
 .B loadkmap
 command (and does not modify the current keymap).
+.SH "CREATE TEXT KEYMAP"
+If the
+.I -t
+(or
+.I --tkeymap
+) option is given
+.B loadkeys
+prints to the standard output a file that may be used as a text
+keymap as expected by
+.B loadkeys
+command (and does not modify the current keymap).
+An optional argument can be used to select the shape of the output
+format:
+.IB "-t" shape
+(or
+.IB "--tkeymap=" shape
+).
+.LP
+Available shapes:
+.LP
+.RS
+.B 2
+default output.
+.RE
+.LP
+.RS
+.B 4
+one line for each keycode.
+.RE
+.LP
+.RS
+.B 8
+one line for each (modifier,keycode) pair.
+.RE
+.LP
+.RS
+.B 16
+one line for each keycode until 1st hole.
+.RE
 .SH "UNICODE MODE"
 .B loadkeys
 automatically detects whether the console is in Unicode or


### PR DESCRIPTION
Before this commit, the loadkeys tool enabled to dump a keymap in various formats (binary, C) but not in its own text format. However, there are some use cases that require text format:

- reformatting;
- golden test;
- round-trip test;
- convert XKB keymaps and thus replace ckbcomp[^1] (requires the upcoming XKB support).

Added the `--tkeymap` (short: `-t`) options to the loadkeys tool, enabling dumping the keymap in *text* format after parsing it.

The output format (shape) can be optionally specified, e.g. `--tkeymap=4` for a full table.

The option name mirrors the `--bkeymap` option that outputs a *binary* table, so that option names are consistent: `--{b,t}keymap`.

[^1]: https://manpages.debian.org/buster/console-setup/ckbcomp.1.en.html