### PR TITLE
dump: Fix rountrip

### DIFF
--- a/src/dumpkeys.c
+++ b/src/dumpkeys.c
@@ -195,6 +195,8 @@ int main(int argc, char *argv[])
 	if (!diac_only) {
 #endif
 		if (!funcs_only) {
+			if ((rc = lk_add_constants(ctx)) < 0)
+				goto fail;
 			lk_dump_keymap(ctx, stdout, table, numeric);
 		}
 #ifdef KDGKBDIACR

--- a/src/libkeymap/dump.c
+++ b/src/libkeymap/dump.c
@@ -321,9 +321,6 @@ void lk_dump_keymaps(struct lk_ctx *ctx, FILE *fd)
 	fprintf(fd, "keymaps");
 
 	for (i = 0; i < ctx->keymap->total; i++) {
-		if (ctx->keywords & LK_KEYWORD_ALTISMETA && i == (i | M_ALT))
-			continue;
-
 		if (!lk_map_exists(ctx, i)) {
 			if (!m)
 				continue;
@@ -496,7 +493,8 @@ no_shorthands:
 		if (table == LK_SHAPE_SEPARATE_LINES) {
 			for (j = 0; j < keymapnr; j++) {
 				//if (buf[j] != K_HOLE)
-				print_bind(ctx, fd, buf[j], i, j, numeric);
+				if (lk_map_exists(ctx, j))
+					print_bind(ctx, fd, buf[j], i, j, numeric);
 			}
 
 			fprintf(fd, "\n");

--- a/src/libkeymap/kmap.c
+++ b/src/libkeymap/kmap.c
@@ -128,8 +128,8 @@ int lk_add_key(struct lk_ctx *ctx, int k_table, int k_index, int keycode)
 	map = lk_array_get_ptr(ctx->keymap, k_table);
 	if (!map) {
 		if (ctx->keywords & LK_KEYWORD_KEYMAPS) {
-			ERR(ctx, _("adding map %d violates explicit keymaps line"),
-			    k_table);
+			ERR(ctx, _("adding map %d for key %d violates explicit keymaps line"),
+			    k_table, k_index);
 			return -1;
 		}
 

--- a/src/loadkeys.c
+++ b/src/loadkeys.c
@@ -287,6 +287,8 @@ int main(int argc, char *argv[])
 		} else if (options & OPT_M) {
 			rc = lk_dump_ctable(ctx, stdout);
 		} else if (options & OPT_T) {
+			if ((rc = lk_add_constants(ctx)) < 0)
+				goto fail;
 			lk_dump_keymap(ctx, stdout, table_shape, 0);
 #ifdef KDGKBDIACR
 			lk_dump_diacs(ctx, stdout);

--- a/tests/helpers/libkeymap-dumpkeys.c
+++ b/tests/helpers/libkeymap-dumpkeys.c
@@ -47,6 +47,7 @@ int main(int argc KBD_ATTR_UNUSED, char **argv)
 	kbdfile_set_file(fp, fopen(argv[1], "r"));
 
 	lk_parse_keymap(ctx, fp);
+	lk_add_constants(ctx);
 	lk_dump_keymap(ctx, stdout, table, numeric);
 	lk_dump_diacs(ctx, stdout);
 

--- a/tests/utils.at
+++ b/tests/utils.at
@@ -34,3 +34,28 @@ AT_SKIP_IF([ test -z "$(tty 2>/dev/null)" ])
 AT_CHECK([LOADKEYS_KEYMAP_PATH="$PWD" $abs_top_builddir/src/loadkeys -q -c -s -u --parse - < "$abs_srcdir/data/keymaps/i386/qwerty/cz.map"])
 AT_CLEANUP
 
+AT_SETUP([loadkeys roundtrip])
+AT_KEYWORDS([utils unittest])
+AT_SKIP_IF([ test -z "$(tty 2>/dev/null)" ])
+for keymap in "qwerty/us" "qwerty/cz"; do
+    for shape in 2 4 8 16; do
+        echo "Testing $keymap, shape: $shape"
+        AT_CHECK([LOADKEYS_KEYMAP_PATH="$PWD" $abs_top_builddir/src/loadkeys -q -u --tkeymap="$shape" "$abs_srcdir/data/keymaps/i386/$keymap.map"], [0], [stdout])
+        cp -f -- stdout expout
+        AT_CHECK([LOADKEYS_KEYMAP_PATH="$PWD" $abs_top_builddir/src/loadkeys -q -u --tkeymap="$shape" expout], [0], [expout])
+    done
+done
+AT_CLEANUP
+
+AT_SETUP([loadkeys pipe tkeymap to mktable])
+AT_KEYWORDS([utils unittest])
+AT_SKIP_IF([ test -z "$(tty 2>/dev/null)" ])
+for keymap in "qwerty/us" "qwerty/cz"; do
+    for shape in 2 4 8 16; do
+        echo "Testing $keymap, shape: $shape"
+        AT_CHECK([LOADKEYS_KEYMAP_PATH="$PWD" $abs_top_builddir/src/loadkeys -q -u --mktable "$abs_srcdir/data/keymaps/i386/$keymap.map"], [0], [stdout])
+        cp -f -- stdout expout
+        AT_CHECK([LOADKEYS_KEYMAP_PATH="$PWD" $abs_top_builddir/src/loadkeys -q -u --tkeymap="$shape" "$abs_srcdir/data/keymaps/i386/$keymap.map" | $abs_top_builddir/src/loadkeys -q -u --mktable -], [0], [expout])
+    done
+done
+AT_CLEANUP


### PR DESCRIPTION
These is a conflict between skipping the keymaps in `lk_dump_keymaps` and forcing all keymaps in `lk_dump_keys`.

Introduced a new function, `lk_dump_keymaps2`, that ensures consistency between the 2 functions.

Fixes #135

TODO:
- [ ] Add tests with all keymap shapes