### PR TITLE
Ignore file mode bits of generated files

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -42,5 +42,4 @@ V_GEN_SED_1 =
 	    -e 's|[@]exec_prefix[@]|$(exec_prefix)|g' \
 	    -e 's|[@]libdir[@]|$(libdir)|g' \
 	    -e 's|[@]includedir[@]|$(includedir)|g' \
-	    <$< >$@ && \
-	chmod --reference=$< $@;
+	    <$< >$@


### PR DESCRIPTION
The correct file mode will be set on install and is not relevant for the generated file.

This also avoids using the non-portable chmod --reference