### PR TITLE
Add keymap for Norwegian Apple ISO keyboard (mac-no.map)

### DIFF
--- a/data/keymaps/i386/qwerty/mac-no.map
+++ b/data/keymaps/i386/qwerty/mac-no.map
@@ -1,0 +1,140 @@
+# mac-no.map
+# Layout: Apple Norwegian ISO
+# Charlie Donovan, Oct 2025
+
+# Tested on Linux 6.12.48 (Debian 13.1.0) in a VirtualBox 7.1 VM & a VMWare 25H2 VM, hosted by 
+# MacOS Ventura 13.7.8 using a Magic Keyboard with Numeric Keypad and a Macbook Pro keyboard
+
+strings as usual
+
+keymaps 0-5,8,9,12
+
+# Function key row
+keycode   1 = Escape          Escape          Escape          Escape          Escape          Escape          Meta_Escape
+keycode  59 = F1
+keycode  60 = F2
+keycode  61 = F3
+keycode  62 = F4
+keycode  63 = F5
+keycode  64 = F6
+keycode  65 = F7
+keycode  66 = F8              Pause
+keycode  67 = F9
+keycode  68 = F10
+keycode  87 = F11
+keycode  88 = F12
+
+# keymaps ->  (map 0)         (map 1)         (map 2)         (map 3)         (map 4)         (map 5)         (map 8)         (map 9)           (map 12)
+
+# Number row
+keycode  41 = apostrophe      section         euro            Ydiaeresis      VoidSymbol      VoidSymbol      Meta_apostrophe
+keycode   2 = one             exclam          copyright       exclamdown      VoidSymbol      VoidSymbol      Meta_one        Meta_exclam
+keycode   3 = two             quotedbl        trademark       registered      VoidSymbol      VoidSymbol      Meta_two        Meta_quotedbl
+keycode   4 = three           numbersign      sterling        yen             VoidSymbol      VoidSymbol      Meta_three      Meta_numbersign
+keycode   5 = four            dollar          euro            cent            VoidSymbol      VoidSymbol      Meta_four       Meta_dollar
+keycode   6 = five            percent         VoidSymbol      permille        VoidSymbol      VoidSymbol      Meta_five       Meta_percent
+keycode   7 = six             ampersand       section         paragraph       VoidSymbol      VoidSymbol      Meta_six        Meta_ampersand
+keycode   8 = seven           slash           bar             backslash       VoidSymbol      VoidSymbol      Meta_seven
+keycode   9 = eight           parenleft       bracketleft     braceleft       VoidSymbol      VoidSymbol      Meta_eight      Meta_parenleft
+keycode  10 = nine            parenright      bracketright    braceright      VoidSymbol      VoidSymbol      Meta_nine       Meta_parenright
+keycode  11 = zero            equal           equal           equal           VoidSymbol      VoidSymbol      Meta_zero       Meta_equal
+keycode  12 = plus            question        plusminus       questiondown    VoidSymbol      VoidSymbol      Meta_plus       Meta_question
+keycode  13 = acute           grave
+keycode  14 = Delete          VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      Meta_BackSpace
+
+# Q row
+keycode  15 = Tab             VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      Meta_Tab
+keycode  16 = q               Q               degree          VoidSymbol      Control_q       Control_q       Meta_q          Meta_Q          Meta_Control_q
+keycode  17 = w               W               VoidSymbol      VoidSymbol      Control_w       Control_w       Meta_w          Meta_W          Meta_Control_w
+keycode  18 = e               E               eacute          Eacute          Control_e       Control_e       Meta_e          Meta_E          Meta_Control_e
+keycode  19 = r               R               thorn           THORN           Control_r       Control_r       Meta_r          Meta_R          Meta_Control_r
+keycode  20 = t               T               dagger          VoidSymbol      Control_t       Control_t       Meta_t          Meta_T          Meta_Control_t
+keycode  21 = y               Y               mu              asciitilde      Control_y       Control_y       Meta_y          Meta_Y          Meta_Control_y
+keycode  22 = u               U               udiaeresis      Udiaeresis      Control_u       Control_u       Meta_u          Meta_U          Meta_Control_u
+keycode  23 = i               I               VoidSymbol      dead_circumflex Control_i       Control_i       Meta_i          Meta_I          Meta_Control_i
+keycode  24 = o               O               oe              OE              Control_o       Control_o       Meta_o          Meta_O          Meta_Control_o
+keycode  25 = p               P               VoidSymbol      VoidSymbol      Control_p       Control_p       Meta_p          Meta_P          Meta_Control_p
+keycode  26 = aring           Aring
+keycode  27 = diaeresis       asciicircum     dead_tilde      dead_circumflex VoidSymbol
+keycode  28 = Return          Return          Return          Return          Return          Return          Meta_Linefeed
+
+# A row
+keycode  58 = Caps_Lock
+keycode  30 = a               A               VoidSymbol      VoidSymbol      Control_a       Control_a       Meta_a          Meta_A          Meta_Control_a
+keycode  31 = s               S               ssharp          VoidSymbol      Control_s       Control_s       Meta_s          Meta_S          Meta_Control_s
+keycode  32 = d               D               VoidSymbol      VoidSymbol      Control_d       Control_d       Meta_d          Meta_D          Meta_Control_d
+keycode  33 = f               F               VoidSymbol      VoidSymbol      Control_f       Control_f       Meta_f          Meta_F          Meta_Control_f
+keycode  34 = g               G               cedilla         macron          Control_g       Control_g       Meta_g          Meta_G          Meta_Control_g
+keycode  35 = h               H               dead_ogonek     dead_breve      Control_h       Control_h       Meta_h          Meta_H          Meta_Control_h
+keycode  36 = j               J               VoidSymbol      notsign         Control_j       Control_j       Meta_j          Meta_J          Meta_Control_j
+keycode  37 = k               K               ordfeminine     masculine       Control_k       Control_k       Meta_k          Meta_K          Meta_Control_k
+keycode  38 = l               L               VoidSymbol      VoidSymbol      Control_l       Control_l       Meta_l          Meta_L          Meta_Control_l
+keycode  39 = oslash          Oslash          odiaeresis      Odiaeresis      VoidSymbol
+keycode  40 = ae              AE
+keycode  43 = at              asterisk        apostrophe      multiply        VoidSymbol      VoidSymbol      Meta_at         Meta_asterisk
+
+# Z row
+keycode  42 = Shift
+keycode  86 = less            greater         VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      Meta_less       Meta_greater
+keycode  44 = z               Z               division        slash           Control_z       Control_z       Meta_z          Meta_Z          Meta_Control_z
+keycode  45 = x               X               VoidSymbol      VoidSymbol      Control_x       Control_x       Meta_x          Meta_X          Meta_Control_x
+keycode  46 = c               C               ccedilla        Ccedilla        Control_c       Control_c       Meta_c          Meta_C          Meta_Control_c
+keycode  47 = v               V               guillemotleft   VoidSymbol      Control_v       Control_v       Meta_v          Meta_V          Meta_Control_v
+keycode  48 = b               B               guillemotright  VoidSymbol      Control_b       Control_b       Meta_b          Meta_B          Meta_Control_b
+keycode  49 = n               N               VoidSymbol      VoidSymbol      Control_n       Control_n       Meta_n          Meta_N          Meta_Control_n
+keycode  50 = m               M               VoidSymbol      VoidSymbol      Control_m       Control_m       Meta_m          Meta_M          Meta_Control_m
+keycode  51 = comma           semicolon       VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      Meta_comma      Meta_semicolon
+keycode  52 = period          colon           VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      Meta_period     Meta_colon
+keycode  53 = minus           underscore      VoidSymbol      VoidSymbol      VoidSymbol      VoidSymbol      Meta_minus      Meta_underscore Meta_Control_underscore
+keycode  54 = Shift
+
+# Space & modifiers
+keycode  29 = Control
+keycode  56 = AltGr
+keycode 125 = Alt
+keycode  57 = space           space           nobreakspace    space           space           space           Meta_space
+keycode 126 = Alt
+keycode 100 = AltGr
+keycode  97 = Control
+
+# Arrow keys
+keycode 103 = Up
+keycode 108 = Down
+keycode 105 = Left
+keycode 106 = Right
+
+# Extended function keys
+keycode  89 = F13
+keycode  90 = F14
+keycode  91 = F15
+keycode  92 = F16
+keycode  93 = F17
+keycode  94 = F18
+keycode  95 = F19
+
+# Navigation block
+keycode 111 = Remove
+keycode 102 = Find
+keycode 107 = Select
+keycode 104 = Prior
+keycode 109 = Next
+
+# Numeric keypad
+keycode  69 = Num_Lock
+keycode  98 = KP_Divide
+keycode  55 = KP_Multiply
+keycode  74 = KP_Subtract
+keycode  78 = KP_Add
+keycode  96 = KP_Enter
+keycode  83 = comma period
+keycode 117 = equal
+keycode  82 = KP_0
+keycode  79 = KP_1
+keycode  80 = KP_2
+keycode  81 = KP_3
+keycode  75 = KP_4
+keycode  76 = KP_5
+keycode  77 = KP_6
+keycode  71 = KP_7
+keycode  72 = KP_8
+keycode  73 = KP_9


### PR DESCRIPTION
Self-contained, no includes, UTF-8 clean.

Tested on Linux 6.12.48 (Debian 13.1.0) in a VirtualBox 7.1 VM, hosted by MacOS Ventura 13.7.8 using a Magic Keyboard with Numeric Keypad and a Macbook Pro keyboard.

Signed-off-by: Charlie Donovan <git.donovan@offshore.rocks>