### PR TITLE
libkbdfile: fix zlib build

### DIFF
--- a/src/libkbdfile/elf-note.h
+++ b/src/libkbdfile/elf-note.h
@@ -26,14 +26,11 @@ int dlsym_many(void **dlp, const char *filename, ...);
  */
 #define DLSYM_ARG(symbol__) &sym_##symbol__, STRINGIFY(symbol__),
 
-/* For symbols being dynamically loaded */
-#define DECLARE_DLSYM(symbol) static typeof(symbol) *sym_##symbol
-
 /*
  * Helper defines, to be done locally before including this header to switch between
  * implementations
  */
-#define DECLARE_SYM(sym__) DECLARE_DLSYM(sym__);
+#define DECLARE_SYM(sym__) static typeof(sym__) *sym_##sym__;
 
 /*
  * Originally from systemd codebase.


### PR DESCRIPTION
Buildroot autobuilders fail to build kbd since version 2.9.0:
https://autobuild.buildroot.net/results/8ff/8ff6c3d940b68069f748f12646f7516ec86172c1/build-end.log
```
kbdfile-zlib.c: In function 'dlopen_note':
elf-note.h:27:30: error: 'sym_gzopen' undeclared (first use in this function); did you mean 'sym_gzopen64'?
   27 | #define DLSYM_ARG(symbol__) &sym_##symbol__, STRINGIFY(symbol__),

kbdfile-zlib.c: In function 'kbdfile_decompressor_zlib': kbdfile-zlib.c:61:15: error: implicit declaration of function 'sym_gzopen'; did you mean 'sym_gzopen64'?
 [-Wimplicit-function-declaration]
   61 |         gzf = sym_gzopen(file->pathname, "rb");
```
