### PR TITLE
Enabling Alt+Shift as Meta for no.map.

### DIFF
--- a/data/keymaps/i386/qwerty/no.map
+++ b/data/keymaps/i386/qwerty/no.map
@@ -1,4 +1,5 @@
-keymaps 0-2,4,6,8,12
+keymaps 0-2,4,6,8-9,12
+alt_is_meta
 include "qwerty-layout"
 include "linux-with-alt-and-altgr"
 	plain keycode  83 = KP_Comma


### PR DESCRIPTION
The majority Norwegian keyboards use the left (and only) Alt button as Meta.
Add map 9 and enable alt_is_meta.

Signed-off-by: Simon Lederhilger <simon.lederhilger@gmail.com>
